### PR TITLE
Move most wordpress API calls serverside

### DIFF
--- a/ApiUtil.ts
+++ b/ApiUtil.ts
@@ -7,9 +7,12 @@ export function fetcher(url: string) {
 }
 
 export function getContent(tab: string, htaId: string) {
-    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${htaId}-${tab}&_fields=content,slug,title`;
+    let overviewURL = `${WORDPRESS_BASE_URL}${htaId}-${tab}`;
     let {data} = useSWR(overviewURL, fetcher);
     let post = _.filter(data, (o) => o.slug === `${htaId}-${tab}`);
 
     return post[0] ? post[0].content.rendered : "";
 }
+
+
+export const WORDPRESS_BASE_URL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?_fields=content,slug,title&cacheBuster=${new Date().getTime()}&slug=`

--- a/components/DataReleasePage.tsx
+++ b/components/DataReleasePage.tsx
@@ -9,6 +9,7 @@ import _ from 'lodash'
 import HtanNavbar from "./HtanNavbar";
 import {getContent} from "../ApiUtil";
 import Footer from "./Footer";
+import {CmsData} from "../types";
 
 
 /**
@@ -28,17 +29,6 @@ function cleanContent(data: CmsData[], slug: string): string {
     }
 
     return content ? content.replace(/<[^>]*>/g, '') : "";
-}
-
-export interface CmsData {
-    slug: string;
-    content: {
-        rendered: string;
-        protected: boolean;
-    };
-    title: {
-        rendered: string;
-    }
 }
 
 export interface DataReleaseProps {

--- a/components/DataReleasePage.tsx
+++ b/components/DataReleasePage.tsx
@@ -36,8 +36,6 @@ export interface DataReleaseProps {
 }
 
 const DataReleasePage = (props: DataReleaseProps) => {
-    let summaryContent = getContent("data-release", "summary-blurb");
-
     return (
         <>
             <HtanNavbar/>
@@ -56,7 +54,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                 </Row>
 
                 <Row className="mt-3">
-                    <span dangerouslySetInnerHTML={{__html: summaryContent}} />
+                    <span dangerouslySetInnerHTML={{__html: props.data[0].content.rendered}}/>
                 </Row>
 
                 <Row className="mt-3">
@@ -72,7 +70,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         <tbody>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta1-short-blurb')}
+                                Human Tumor Atlas Pilot Project (HTAPP)
                             </td>
                             <td>HTA1 ATLAS TYPE</td>
                             <td>HTA1 LEAD INSTITUTION</td>
@@ -84,7 +82,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta2-short-blurb')}
+                                Pre-Cancer Atlas: Pilot Project (PCAPP)
                             </td>
                             <td>HTA2 ATLAS TYPE</td>
                             <td>HTA2 LEAD INSTITUTION</td>
@@ -96,7 +94,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta3-short-blurb')}
+                                Pre-Cancer Atlas: Lung Cancer
                             </td>
                             <td>HTA3 ATLAS TYPE</td>
                             <td>HTA3 LEAD INSTITUTION</td>
@@ -108,7 +106,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta4-short-blurb')}
+                                Center for Pediatric Tumor Cell Atlas
                             </td>
                             <td>HTA4 ATLAS TYPE</td>
                             <td>HTA4 LEAD INSTITUTION</td>
@@ -120,7 +118,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta5-short-blurb')}
+                                The Cellular Geography of Therapeutic Resistance in Cancer
                             </td>
                             <td>HTA5 ATLAS TYPE</td>
                             <td>HTA5 LEAD INSTITUTION</td>
@@ -132,7 +130,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta6-short-blurb')}
+                                Pre-Cancer Atlas:  Breast Cancer
                             </td>
                             <td>HTA6 ATLAS TYPE</td>
                             <td>HTA6 LEAD INSTITUTION</td>
@@ -144,7 +142,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta7-short-blurb')}
+                                Pre-Cancer Atlas:  Melanoma
                             </td>
                             <td>HTA7 ATLAS TYPE</td>
                             <td>HTA7 LEAD INSTITUTION</td>
@@ -156,7 +154,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta8-short-blurb')}
+                                Transition to Metastatic State: Lung Cancer, Pancreatic Cancer and Brain Metastasis
                             </td>
                             <td>HTA8 ATLAS TYPE</td>
                             <td>HTA8 LEAD INSTITUTION</td>
@@ -168,7 +166,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta9-short-blurb')}
+                                Omic and Multidimensional Spatial (OMS) Atlas of Metastatic Breast Cancers
                             </td>
                             <td>HTA9 ATLAS TYPE</td>
                             <td>HTA9 LEAD INSTITUTION</td>
@@ -180,7 +178,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta10-short-blurb')}
+                                Pre-Cancer Atlas:  Familial Adenomatous Polyposis (FAP)
                             </td>
                             <td>HTA10 ATLAS TYPE</td>
                             <td>HTA10 LEAD INSTITUTION</td>
@@ -192,7 +190,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta11-short-blurb')}
+                                Pre-Cancer Atlas:  Colorectal Cancer (CRC)
                             </td>
                             <td>HTA11 ATLAS TYPE</td>
                             <td>HTA11 LEAD INSTITUTION</td>
@@ -204,7 +202,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                         </tr>
                         <tr>
                             <td>
-                                {cleanContent(props.data, 'hta12-short-blurb')}
+                                Washington University Human Tumor Atlas Research Center
                             </td>
                             <td>HTA12 ATLAS TYPE</td>
                             <td>HTA12 LEAD INSTITUTION</td>

--- a/components/DataReleasePage.tsx
+++ b/components/DataReleasePage.tsx
@@ -8,6 +8,7 @@ import _ from 'lodash'
 
 import HtanNavbar from "./HtanNavbar";
 import {getContent} from "../ApiUtil";
+import Footer from "./Footer";
 
 
 /**
@@ -227,6 +228,7 @@ const DataReleasePage = (props: DataReleaseProps) => {
                     </Table>
                 </Row>
             </Container>
+            <Footer/>
         </>
     );
 }

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -35,7 +35,7 @@ const HomePage = (data: {data: HomeProps}) => {
             </Row>
 
             <Row className="justify-content-md-center mt-5">
-                <Col md={{span: 4}}>
+                <Col md={{span: 7}}>
                     <span dangerouslySetInnerHTML={{ __html: heroBlurb[0].content.rendered}}></span>
                 </Col>
             </Row>
@@ -45,7 +45,6 @@ const HomePage = (data: {data: HomeProps}) => {
                     <Button href="/data" variant="primary" className="mr-4">
                         Explore the Data
                     </Button>
-                    <Button variant="secondary">Learn More</Button>
                 </ButtonToolbar>
             </Row>
         </Jumbotron>

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -9,9 +9,13 @@ import Container from "react-bootstrap/Container";
 import Jumbotron from "react-bootstrap/Jumbotron";
 import {getContent} from "../ApiUtil";
 import _ from "lodash";
+import {CmsData} from "../types";
 
+export interface HomeProps {
+    data: CmsData[];
+}
 
-const HomePage = (data: {data: any}) => {
+const HomePage = (data: {data: HomeProps}) => {
     let props = data.data.data
 
     let homepageCard1 = getContent("card-1", "homepage");

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -8,16 +8,20 @@ import CardGroup from "react-bootstrap/CardGroup";
 import Container from "react-bootstrap/Container";
 import Jumbotron from "react-bootstrap/Jumbotron";
 import {getContent} from "../ApiUtil";
+import _ from "lodash";
 
 
-const HomePage = () => {
-    let heroBlurb = getContent("hero-blurb", "homepage");
+const HomePage = (data: {data: any}) => {
+    let props = data.data.data
+
     let homepageCard1 = getContent("card-1", "homepage");
     let homepageCard2 = getContent("card-2", "homepage");
     let homepageCard3 = getContent("card-3", "homepage");
     let homepageCard4 = getContent("card-4", "homepage");
     let homepageCard5 = getContent("card-5", "homepage");
     let homepageCard6 = getContent("card-6", "homepage");
+
+    let heroBlurb = _.filter(props, (o: any) => o.slug === `homepage-hero-blurb`);
 
     return (
     <Container>
@@ -28,7 +32,7 @@ const HomePage = () => {
 
             <Row className="justify-content-md-center mt-5">
                 <Col md={{span: 4}}>
-                    <span dangerouslySetInnerHTML={{ __html: heroBlurb}}></span>
+                    <span dangerouslySetInnerHTML={{ __html: heroBlurb[0].content.rendered}}></span>
                 </Col>
             </Row>
 

--- a/pages/data/index.tsx
+++ b/pages/data/index.tsx
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import React from "react";
 
 import DataReleasePage, {DataReleaseProps} from "../../components/DataReleasePage";
+import {WORDPRESS_BASE_URL} from "../../ApiUtil";
 
 export async function getServerSideProps(): Promise<{props: DataReleaseProps}> {
 
@@ -22,8 +23,8 @@ export async function getServerSideProps(): Promise<{props: DataReleaseProps}> {
         "hta2-short-blurb",
         "hta1-short-blurb"
     ]
-    const url = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs1)}&_fields=content,slug,title&cacheBuster=${new Date().getTime()}`;
-    const url2 = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs2)}&_fields=content,slug,title&cacheBuster=${new Date().getTime()}`;
+    const url = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs1)}`;
+    const url2 = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs2)}`;
     const res = await fetch(url);
     const res2 = await fetch(url2);
     let data = await res.json();

--- a/pages/data/index.tsx
+++ b/pages/data/index.tsx
@@ -6,8 +6,24 @@ import DataReleasePage, {DataReleaseProps} from "../../components/DataReleasePag
 export async function getServerSideProps(): Promise<{props: DataReleaseProps}> {
 
     // TODO we should have better variable names here
-    const url = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=hta12-short-blurb,hta11-short-blurb,hta10-short-blurb,hta9-short-blurb,hta8-short-blurb,hta7-short-blurb&_fields=content,slug,title&cacheBuster=${new Date().getTime()}`;
-    const url2 = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=hta6-short-blurb,hta5-short-blurb,hta4-short-blurb,hta3-short-blurb,hta2-short-blurb,hta1-short-blurb&_fields=content,slug,title&cacheBuster=${new Date().getTime()}`;
+    let slugs1 = [
+        "hta12-short-blurb",
+        "hta11-short-blurb",
+        "hta10-short-blurb",
+        "hta9-short-blurb",
+        "hta8-short-blurb",
+        "hta7-short-blurb"
+    ]
+    let slugs2 = [
+        "hta6-short-blurb",
+        "hta5-short-blurb",
+        "hta4-short-blurb",
+        "hta3-short-blurb",
+        "hta2-short-blurb",
+        "hta1-short-blurb"
+    ]
+    const url = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs1)}&_fields=content,slug,title&cacheBuster=${new Date().getTime()}`;
+    const url2 = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs2)}&_fields=content,slug,title&cacheBuster=${new Date().getTime()}`;
     const res = await fetch(url);
     const res2 = await fetch(url2);
     let data = await res.json();

--- a/pages/data/index.tsx
+++ b/pages/data/index.tsx
@@ -3,39 +3,14 @@ import React from "react";
 
 import DataReleasePage, {DataReleaseProps} from "../../components/DataReleasePage";
 import {WORDPRESS_BASE_URL} from "../../ApiUtil";
+import {GetServerSideProps} from "next";
 
-export async function getServerSideProps(): Promise<{props: DataReleaseProps}> {
-
-    // TODO we should have better variable names here
-    let slugs1 = [
-        "hta12-short-blurb",
-        "hta11-short-blurb",
-        "hta10-short-blurb",
-        "hta9-short-blurb",
-        "hta8-short-blurb",
-        "hta7-short-blurb"
-    ]
-    let slugs2 = [
-        "hta6-short-blurb",
-        "hta5-short-blurb",
-        "hta4-short-blurb",
-        "hta3-short-blurb",
-        "hta2-short-blurb",
-        "hta1-short-blurb"
-    ]
-    const url = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs1)}`;
-    const url2 = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs2)}`;
-    const res = await fetch(url);
-    const res2 = await fetch(url2);
+export const getServerSideProps: GetServerSideProps = async context => {
+    let slugs = ["summary-blurb-data-release"];
+    let overviewURL = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs)}`;
+    let res = await fetch(overviewURL);
     let data = await res.json();
-    let data2 = await res2.json();
-    data = data.concat(data2);
-
-    return {
-        props: {
-            data,
-        },
-    }
+    return {props: {data}}
 }
 
 const DataRelease = (props: DataReleaseProps) => <DataReleasePage {...props} />;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,8 +5,13 @@ import HomePage from "../components/HomePage";
 import Footer from "../components/Footer";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
+import {CmsData} from "../types";
 
-const Home = (data: any) => {
+export interface HomeProps {
+    data: CmsData[];
+}
+
+const Home = (data: HomeProps) => {
     return (
         <>
             <HtanNavbar/>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
     let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
     let res = await fetch(overviewURL);
     let data = await res.json();
-    return {props: {data: data}}
+    return {props: {data}}
 }
 
 export default Home;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,13 +3,34 @@ import React from "react";
 import HtanNavbar from "../components/HtanNavbar";
 import HomePage from "../components/HomePage";
 import Footer from "../components/Footer";
+import {GetServerSideProps} from "next";
+import fetch from "node-fetch";
 
-const Home = () => (
-    <>
-        <HtanNavbar/>
-        <HomePage/>
-        <Footer/>
-    </>
-);
+const Home = (data: any) => {
+    return (
+        <>
+            <HtanNavbar/>
+            <HomePage data={data}/>
+            <Footer/>
+        </>
+    );
+}
+
+export const getServerSideProps: GetServerSideProps = async context => {
+    let slugs = [
+        "homepage-card-1",
+        "homepage-card-2",
+        "homepage-card-3",
+        "homepage-card-4",
+        "homepage-card-5",
+        "homepage-card-6",
+        "homepage-hero-blurb"
+    ];
+
+    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let res = await fetch(overviewURL);
+    let data = await res.json();
+    return {props: {data: data}}
+}
 
 export default Home;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,16 +17,7 @@ const Home = (data: any) => {
 }
 
 export const getServerSideProps: GetServerSideProps = async context => {
-    let slugs = [
-        "homepage-card-1",
-        "homepage-card-2",
-        "homepage-card-3",
-        "homepage-card-4",
-        "homepage-card-5",
-        "homepage-card-6",
-        "homepage-hero-blurb"
-    ];
-
+    let slugs = ["homepage-hero-blurb"];
     let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
     let res = await fetch(overviewURL);
     let data = await res.json();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import Footer from "../components/Footer";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
 import {CmsData} from "../types";
+import {WORDPRESS_BASE_URL} from "../ApiUtil";
 
 export interface HomeProps {
     data: CmsData[];
@@ -23,7 +24,7 @@ const Home = (data: HomeProps) => {
 
 export const getServerSideProps: GetServerSideProps = async context => {
     let slugs = ["homepage-hero-blurb"];
-    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let overviewURL = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs)}`;
     let res = await fetch(overviewURL);
     let data = await res.json();
     return {props: {data}}

--- a/pages/standards/biospecimens.tsx
+++ b/pages/standards/biospecimens.tsx
@@ -6,8 +6,13 @@ import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch"
+import {CmsData} from "../../types";
 
-function Biospecimens(data: any) {
+export interface BiospecimenProps {
+    data: CmsData[];
+}
+
+function Biospecimens(data: BiospecimenProps) {
     return (
         <>
             <HtanNavbar/>

--- a/pages/standards/biospecimens.tsx
+++ b/pages/standards/biospecimens.tsx
@@ -4,10 +4,10 @@ import Footer from "../../components/Footer";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
-import {getContent} from "../../ApiUtil";
+import {GetServerSideProps} from "next";
+import fetch from "node-fetch"
 
-function Biospecimens() {
-    const content = getContent("cds-blurb","data-standards");
+function Biospecimens(data: any) {
     return (
         <>
             <HtanNavbar/>
@@ -22,12 +22,20 @@ function Biospecimens() {
                     </Breadcrumb>
                 </Row>
                 <Row>
-                    <span dangerouslySetInnerHTML={{__html: content}}></span>
+                    <span dangerouslySetInnerHTML={{__html: data.data[0].content.rendered}}></span>
                 </Row>
             </Container>
             <Footer/>
         </>
     );
+}
+
+export const getServerSideProps: GetServerSideProps = async context => {
+    let slugs = ["data-standards-biospecimen-blurb"];
+    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let res = await fetch(overviewURL);
+    let data = await res.json();
+    return {props: {data}}
 }
 
 export default Biospecimens;

--- a/pages/standards/biospecimens.tsx
+++ b/pages/standards/biospecimens.tsx
@@ -7,6 +7,7 @@ import Breadcrumb from "react-bootstrap/Breadcrumb";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch"
 import {CmsData} from "../../types";
+import {WORDPRESS_BASE_URL} from "../../ApiUtil";
 
 export interface BiospecimenProps {
     data: CmsData[];
@@ -37,7 +38,7 @@ function Biospecimens(data: BiospecimenProps) {
 
 export const getServerSideProps: GetServerSideProps = async context => {
     let slugs = ["data-standards-biospecimen-blurb"];
-    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let overviewURL = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs)}`;
     let res = await fetch(overviewURL);
     let data = await res.json();
     return {props: {data}}

--- a/pages/standards/cds.tsx
+++ b/pages/standards/cds.tsx
@@ -7,6 +7,7 @@ import Breadcrumb from "react-bootstrap/Breadcrumb";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
 import {CmsData} from "../../types";
+import {WORDPRESS_BASE_URL} from "../../ApiUtil";
 
 export interface CdsProps {
     data: CmsData[];
@@ -37,7 +38,7 @@ function Cds(data: CdsProps) {
 
 export const getServerSideProps: GetServerSideProps = async context => {
     let slugs = ["data-standards-cds-blurb"];
-    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let overviewURL = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs)}`;
     let res = await fetch(overviewURL);
     let data = await res.json();
     return {props: {data}}

--- a/pages/standards/cds.tsx
+++ b/pages/standards/cds.tsx
@@ -4,10 +4,10 @@ import Footer from "../../components/Footer";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
-import {getContent} from "../../ApiUtil";
+import {GetServerSideProps} from "next";
+import fetch from "node-fetch";
 
-function Cds() {
-    const content = getContent("cds-blurb","data-standards");
+function Cds(data: any) {
     return (
        <>
             <HtanNavbar/>
@@ -22,12 +22,20 @@ function Cds() {
                     </Breadcrumb>
                 </Row>
                 <Row>
-                    <span dangerouslySetInnerHTML={{__html: content}}></span>
+                    <span dangerouslySetInnerHTML={{__html: data.data[0].content.rendered}}></span>
                 </Row>
             </Container>
             <Footer/>
         </>
     );
+}
+
+export const getServerSideProps: GetServerSideProps = async context => {
+    let slugs = ["data-standards-cds-blurb"];
+    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let res = await fetch(overviewURL);
+    let data = await res.json();
+    return {props: {data}}
 }
 
 export default Cds;

--- a/pages/standards/cds.tsx
+++ b/pages/standards/cds.tsx
@@ -6,8 +6,13 @@ import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
+import {CmsData} from "../../types";
 
-function Cds(data: any) {
+export interface CdsProps {
+    data: CmsData[];
+}
+
+function Cds(data: CdsProps) {
     return (
        <>
             <HtanNavbar/>

--- a/pages/standards/imaging.tsx
+++ b/pages/standards/imaging.tsx
@@ -6,8 +6,12 @@ import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
+import {CmsData} from "../../types";
 
-function Imaging(data: any) {
+export interface ImagingProps {
+    data: CmsData[];
+}
+function Imaging(data: ImagingProps) {
     return (
         <>
             <HtanNavbar/>

--- a/pages/standards/imaging.tsx
+++ b/pages/standards/imaging.tsx
@@ -4,10 +4,10 @@ import Footer from "../../components/Footer";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
-import {getContent} from "../../ApiUtil";
+import {GetServerSideProps} from "next";
+import fetch from "node-fetch";
 
-function Imaging() {
-    const content = getContent("imaging-blurb","data-standards");
+function Imaging(data: any) {
     return (
         <>
             <HtanNavbar/>
@@ -22,12 +22,20 @@ function Imaging() {
                     </Breadcrumb>
                 </Row>
                 <Row>
-                    <span dangerouslySetInnerHTML={{__html: content}}></span>
+                    <span dangerouslySetInnerHTML={{__html: data.data[0].content.rendered}}></span>
                 </Row>
             </Container>
             <Footer/>
         </>
     );
+}
+
+export const getServerSideProps: GetServerSideProps = async context => {
+    let slugs = ["data-standards-imaging-blurb"];
+    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let res = await fetch(overviewURL);
+    let data = await res.json();
+    return {props: {data}}
 }
 
 export default Imaging;

--- a/pages/standards/imaging.tsx
+++ b/pages/standards/imaging.tsx
@@ -7,6 +7,7 @@ import Breadcrumb from "react-bootstrap/Breadcrumb";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
 import {CmsData} from "../../types";
+import {WORDPRESS_BASE_URL} from "../../ApiUtil";
 
 export interface ImagingProps {
     data: CmsData[];
@@ -36,7 +37,7 @@ function Imaging(data: ImagingProps) {
 
 export const getServerSideProps: GetServerSideProps = async context => {
     let slugs = ["data-standards-imaging-blurb"];
-    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let overviewURL = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs)}`;
     let res = await fetch(overviewURL);
     let data = await res.json();
     return {props: {data}}

--- a/pages/standards/index.tsx
+++ b/pages/standards/index.tsx
@@ -3,12 +3,12 @@ import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 import HtanNavbar from "../../components/HtanNavbar";
-import {getContent} from "../../ApiUtil";
 import Footer from "../../components/Footer";
 import Link from "next/link";
+import {GetServerSideProps} from "next";
+import fetch from "node-fetch";
 
-const Standards = () => {
-    const content = getContent("data-standards","summary-blurb");
+const Standards = (data: any) => {
     return (
         <>
             <HtanNavbar/>
@@ -26,7 +26,7 @@ const Standards = () => {
                     <h1>Data Standards</h1>
                 </Row>
                 <Row className="mt-3">
-                    <span dangerouslySetInnerHTML={{__html: content}} />
+                    <span dangerouslySetInnerHTML={{__html: data.data[0].content.rendered}} />
                 </Row>
                 <Row className="mt-3">
                     <h4>
@@ -62,5 +62,13 @@ const Standards = () => {
         </>
     )
 };
+
+export const getServerSideProps: GetServerSideProps = async context => {
+    let slugs = ["summary-blurb-data-standards"];
+    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let res = await fetch(overviewURL);
+    let data = await res.json();
+    return {props: {data}}
+}
 
 export default Standards

--- a/pages/standards/index.tsx
+++ b/pages/standards/index.tsx
@@ -7,8 +7,13 @@ import Footer from "../../components/Footer";
 import Link from "next/link";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
+import {CmsData} from "../../types";
 
-const Standards = (data: any) => {
+export interface StandardsProps {
+    data: CmsData[];
+}
+
+const Standards = (data: StandardsProps) => {
     return (
         <>
             <HtanNavbar/>

--- a/pages/standards/index.tsx
+++ b/pages/standards/index.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
 import {CmsData} from "../../types";
+import {WORDPRESS_BASE_URL} from "../../ApiUtil";
 
 export interface StandardsProps {
     data: CmsData[];
@@ -70,7 +71,7 @@ const Standards = (data: StandardsProps) => {
 
 export const getServerSideProps: GetServerSideProps = async context => {
     let slugs = ["summary-blurb-data-standards"];
-    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let overviewURL = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs)}`;
     let res = await fetch(overviewURL);
     let data = await res.json();
     return {props: {data}}

--- a/pages/standards/rnaseq.tsx
+++ b/pages/standards/rnaseq.tsx
@@ -7,6 +7,7 @@ import Breadcrumb from "react-bootstrap/Breadcrumb";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
 import {CmsData} from "../../types";
+import {WORDPRESS_BASE_URL} from "../../ApiUtil";
 
 export interface RnaseqProps {
     data: CmsData[];
@@ -37,7 +38,7 @@ function Rnaseq(data: RnaseqProps) {
 
 export const getServerSideProps: GetServerSideProps = async context => {
     let slugs = ["data-standards-rnaseq-blurb"];
-    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let overviewURL = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs)}`;
     let res = await fetch(overviewURL);
     let data = await res.json();
     return {props: {data}}

--- a/pages/standards/rnaseq.tsx
+++ b/pages/standards/rnaseq.tsx
@@ -6,8 +6,13 @@ import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch";
+import {CmsData} from "../../types";
 
-function Rnaseq(data: any) {
+export interface RnaseqProps {
+    data: CmsData[];
+}
+
+function Rnaseq(data: RnaseqProps) {
     return (
         <>
             <HtanNavbar/>

--- a/pages/standards/rnaseq.tsx
+++ b/pages/standards/rnaseq.tsx
@@ -4,10 +4,10 @@ import Footer from "../../components/Footer";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
-import {getContent} from "../../ApiUtil";
+import {GetServerSideProps} from "next";
+import fetch from "node-fetch";
 
-function Rnaseq() {
-    const content = getContent("rnaseq-blurb","data-standards");
+function Rnaseq(data: any) {
     return (
         <>
             <HtanNavbar/>
@@ -22,12 +22,20 @@ function Rnaseq() {
                     </Breadcrumb>
                 </Row>
                 <Row>
-                    <span dangerouslySetInnerHTML={{__html: content}}></span>
+                    <span dangerouslySetInnerHTML={{__html: data.data[0].content.rendered}}></span>
                 </Row>
             </Container>
             <Footer/>
         </>
     );
+}
+
+export const getServerSideProps: GetServerSideProps = async context => {
+    let slugs = ["data-standards-rnaseq-blurb"];
+    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let res = await fetch(overviewURL);
+    let data = await res.json();
+    return {props: {data}}
 }
 
 export default Rnaseq;

--- a/pages/transfer.tsx
+++ b/pages/transfer.tsx
@@ -2,13 +2,12 @@ import React from "react";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Breadcrumb from "react-bootstrap/Breadcrumb";
-
 import HtanNavbar from "../components/HtanNavbar";
-import {getContent} from "../ApiUtil";
 import Footer from "../components/Footer";
+import {GetServerSideProps} from "next";
+import fetch from "node-fetch"
 
-const Transfer = () => {
-    const content = getContent("data-transfer","summary-blurb");
+const Transfer = (data: any) => {
     return (
     <>
         <HtanNavbar/>
@@ -25,12 +24,20 @@ const Transfer = () => {
                 <h1>Data Transfer</h1>
             </Row>
             <Row className="mt-3">
-                <span dangerouslySetInnerHTML={{__html: content}} />
+                <span dangerouslySetInnerHTML={{__html: data.data[0].content.rendered}} />
             </Row>
         </Container>
         <Footer/>
     </>
     )
 };
+
+export const getServerSideProps: GetServerSideProps = async context => {
+    let slugs = ["summary-blurb-data-transfer"];
+    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let res = await fetch(overviewURL);
+    let data = await res.json();
+    return {props: {data}}
+}
 
 export default Transfer

--- a/pages/transfer.tsx
+++ b/pages/transfer.tsx
@@ -6,8 +6,13 @@ import HtanNavbar from "../components/HtanNavbar";
 import Footer from "../components/Footer";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch"
+import {CmsData} from "../types";
 
-const Transfer = (data: any) => {
+export interface TransferProps {
+    data: CmsData[];
+}
+
+const Transfer = (data: TransferProps) => {
     return (
     <>
         <HtanNavbar/>

--- a/pages/transfer.tsx
+++ b/pages/transfer.tsx
@@ -7,6 +7,7 @@ import Footer from "../components/Footer";
 import {GetServerSideProps} from "next";
 import fetch from "node-fetch"
 import {CmsData} from "../types";
+import {WORDPRESS_BASE_URL} from "../ApiUtil";
 
 export interface TransferProps {
     data: CmsData[];
@@ -39,7 +40,7 @@ const Transfer = (data: TransferProps) => {
 
 export const getServerSideProps: GetServerSideProps = async context => {
     let slugs = ["summary-blurb-data-transfer"];
-    let overviewURL = `https://humantumoratlas.org/wp-json/wp/v2/pages/?slug=${JSON.stringify(slugs)}&_fields=content,slug,title`;
+    let overviewURL = `${WORDPRESS_BASE_URL}${JSON.stringify(slugs)}`;
     let res = await fetch(overviewURL);
     let data = await res.json();
     return {props: {data}}

--- a/types.ts
+++ b/types.ts
@@ -8,3 +8,4 @@ export interface CmsData {
         rendered: string;
     }
 }
+

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,10 @@
+export interface CmsData {
+    slug: string;
+    content: {
+        rendered: string;
+        protected: boolean;
+    };
+    title: {
+        rendered: string;
+    }
+}


### PR DESCRIPTION
Ethan Cerami mentioned that the "lag" in the UI was something to remove. 

The lag was caused by the remote wordpress API calls happening client side. To remove the lag, I've moved all the API calls server side by wrapping them in `getServerSideProps` on each page. 

There are some other small bug fixes here as well:
- removed extra homepage button, widened hero blurb
- created top level `types.ts` file to reuse type defs
- add footer to data release page
- remove wordpress calls for data release page and hardcode values as per e. cerami request