### PR TITLE
Add ucsc single cell viewer to derived data tab

### DIFF
--- a/components/AtlasDataTable.tsx
+++ b/components/AtlasDataTable.tsx
@@ -1,11 +1,28 @@
 import React from "react";
 import {Table} from "react-bootstrap";
 import _ from 'lodash';
-import {SubCategory} from "../types";
+import {SubCategory, Attribute} from "../types";
 import Tooltip from "rc-tooltip";
+import { isArray } from "util";
+
 
 type AtlasDataTableProps = {
     subcategoryData:SubCategory
+}
+
+function renderTableCellValue(att:Attribute, val:any): JSX.Element {
+    let el = <span>{val}</span>
+
+    if (att && typeof(att.schemaMetadata) === 'object' &&
+            att.schemaMetadata.renderType) {
+        if (att.schemaMetadata.renderType === 'href') {
+            el = <a href={val}>{val}</a>
+        } else if (att.schemaMetadata.renderType === "scBrowser") {
+            el = <a href={`${val}`.replace("https://humantumoratlas.org/","/")} className={`btn btn-primary`}>View</a>
+        }
+    }
+
+    return el;
 }
 
 export const AtlasDataTable: React.FunctionComponent<AtlasDataTableProps> = ({ subcategoryData }) => {
@@ -27,25 +44,23 @@ export const AtlasDataTable: React.FunctionComponent<AtlasDataTableProps> = ({ s
             </thead>
             <tbody>
             {
-                subcategoryData.data.values.map((vals, i)=>{
-                    const att = atts[i];
-                    const meta = {}
-                    if (att && att.schemaMetadata) {
-                        const meta = JSON.stringify(att.schemaMetadata);
-                    }
+                subcategoryData.data.values.map((vals,i)=>{
                     if (vals && _.isArray(vals)) {
-                        return <tr key={i}>
-                            {
-                                vals.map((val: any, i: number) => {
-                                        return <td key={`${i}`}>
+                        return (<tr key={i}>
+                                {vals.map((val:any,j:number) => {
+                                    const att = atts[j];
+                                    const meta = (att && att.schemaMetadata)? JSON.stringify(att.schemaMetadata) : JSON.stringify({});
+
+                                    return (
+                                        <td key={`cell${j}`}>
                                             <Tooltip visible={false} overlay={meta}>
-                                                <span>{val}</span>
+                                                {renderTableCellValue(att, val)}
                                             </Tooltip>
                                         </td>
-                                    }
-                                )
-                            }
-                        </tr>
+                                    );
+                                })}
+                            </tr>
+                        );
                     } else {
                         console.log(vals);
                         return null;

--- a/data/data.json
+++ b/data/data.json
@@ -413,10 +413,12 @@
                   }
                ],
                "values": [
+                  [
                     "ScRNA-seqLevel4",
                      "eg_project_file3.txt",
                      "https://humantumoratlas.org/single_cell?ds=nsclc_vdj",
                      "txt"
+                  ]
                ]
             }
          },

--- a/pages/atlas/[id].tsx
+++ b/pages/atlas/[id].tsx
@@ -26,7 +26,6 @@ interface IPostProps {
 }
 
 const PostContent: React.FunctionComponent<{ wpAtlas:WPAtlas, synapseAtlas?:SynapseAtlas }> = ({ wpAtlas, synapseAtlas }) => {
-
     let mergedClinicalAndBiospecimenData: Category;
     if (synapseAtlas) {
         mergedClinicalAndBiospecimenData = Object.assign({}, synapseAtlas.clinical, synapseAtlas.biospecimen);

--- a/types.ts
+++ b/types.ts
@@ -11,12 +11,17 @@ export interface CmsData {
 
 export interface SubCategory {
     data: {
-        attributes:any[];
+        attributes:Attribute[];
         values:any[];
     };
     dataLink:string;
 };
 
+export interface Attribute {
+    name: string,
+    description: string,
+    schemaMetadata: { renderType?: string }
+}
 
 export interface Category {
     [subcat:string]:SubCategory


### PR DESCRIPTION
- Add ucsc single cell browser to derived data tab
- Fix JSON (values should array of arrays)

see e.g.

https://htan-portal-nextjs-git-fork-inodb-add-ucsc-single-cell-tab.htan.now.sh/atlas/hta2

Future thoughts, can be done in follow up PRs:

- how should we name the datasets, could use synapse id or some other HTAN identifier for the scrnaseq file

Related:

https://github.com/ncihtan/htan-portal/issues/49
https://github.com/ncihtan/htan-portal/issues/46
https://github.com/ncihtan/htan-portal/issues/41

Screenshots:

- Derived data tab in `/atlas/hta2`

![Screen Shot 2020-05-11 at 6 57 03 PM](https://user-images.githubusercontent.com/1334004/81620215-5f942a80-93b9-11ea-85e1-345fc3b4955a.png)


- When you click on "View"

    <img width="938" alt="Screen Shot 2020-05-09 at 10 50 30 AM" src="https://user-images.githubusercontent.com/1334004/81476994-f8248200-91e2-11ea-9b00-ab40b74d5cf9.png">
