### PR TITLE
Add dashboard numbers on homepage

### DIFF
--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -13,10 +13,33 @@ export interface IHomePropsProps {
     cards: any[];
 }
 
+function dashboardIcon(text:string, description:string) {
+    return (
+        <Col key={`icon-${description}`} xs lg="2" >
+            <div style={{textAlign:"center"}}>
+                <div style={{color:"white",fontSize:"60px", lineHeight:"70px"}}>
+                    {text}
+                </div>
+                <div style={{color:"white",fontSize:"20px"}}>
+                    {description}
+                </div>
+            </div>
+        </Col>
+    );
+}
+
+
 const HomePage: React.FunctionComponent<IHomePropsProps> = ({ hero_blurb, cards}) => {
 
+    const dashboardData = [
+        {text: "12", description: "Atlases"},
+        {text: "11", description: "Organs"},
+        {text: ">1K", description: "Participants"},
+        {text: ">10K", description: "Biospecimens"},
+    ];
+
     return (<>
-        <Jumbotron className={"text-center"}>
+        <Jumbotron className={"text-center"} style={{marginBottom:"0px"}}>
             <Row className="justify-content-md-center">
                 <h1>Human Tumor Atlas Network Data Portal</h1>
             </Row>
@@ -35,6 +58,11 @@ const HomePage: React.FunctionComponent<IHomePropsProps> = ({ hero_blurb, cards}
                 </ButtonToolbar>
             </Row>
         </Jumbotron>
+    <Container fluid style={{backgroundColor:"#6B618B",paddingTop:"60px",paddingBottom:"60px"}}>
+        <Row className="justify-content-md-center" >
+            {dashboardData.map((icon) => dashboardIcon(icon.text, icon.description))}
+        </Row>
+    </Container>
     <Container>
         <Row className="justify-content-md-center mt-5">
             <Col md={{span: 8}}>


### PR DESCRIPTION
something like:
<img width="1412" alt="Screen Shot 2020-10-21 at 6 06 32 PM" src="https://user-images.githubusercontent.com/1334004/96792323-2c25e500-13c8-11eb-80a6-24e81bede818.png">

Can tweak numbers/style later i guess. I used some palette generator for colors:

<img width="500" alt="Screen Shot 2020-10-21 at 6 06 32 PM" src="https://user-images.githubusercontent.com/1334004/96881389-37baef80-144c-11eb-828d-e246a3dd8fd4.png">
