### PR TITLE
Prettier loading indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-portal": "^4.2.1",
     "react-select": "^3.1.0",
     "react-spinkit": "^3.0.0",
+    "react-spinners": "^0.10.4",
     "roman-numerals": "^0.3.2",
     "styled-components": "^5.1.0",
     "swr": "^0.1.18",

--- a/pages/explore.tsx
+++ b/pages/explore.tsx
@@ -28,6 +28,8 @@ import {
 } from '../lib/types';
 import FilterCheckList from '../components/FilterPanel/FilterCheckList';
 import {IPromiseBasedObservable} from "mobx-utils";
+import {ScaleLoader} from "react-spinners";
+import styles from "./styles.module.scss";
 
 export const getStaticProps: GetStaticProps = async (context) => {
     let slugs = ['summary-blurb-data-release'];
@@ -195,7 +197,13 @@ class Search extends React.Component<{ wpData: WPAtlas[] }, IFilterProps> {
 
         if (!this.dataLoadingPromise || this.dataLoadingPromise.state === "pending") {
             // TODO: Pretty this up
-            return <span>Loading</span>;
+            return (
+                <div
+                    className={styles.loadingIndicator}
+                >
+                    <ScaleLoader/>
+                </div>
+            );
         }
         if (this.filteredFiles) {
             return (

--- a/pages/styles.module.scss
+++ b/pages/styles.module.scss
@@ -1,0 +1,9 @@
+.loadingIndicator {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  z-index: 10000;
+  text-align: center;
+  transform: translate(-50%, -50%);
+  animation: fadein 1s;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,7 +300,7 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.9":
+"@emotion/core@^10.0.35", "@emotion/core@^10.0.9":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
   integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
@@ -4853,6 +4853,13 @@ react-spinkit@^3.0.0:
     loaders.css "^0.1.2"
     object-assign "^4.1.0"
     prop-types "^15.5.8"
+
+react-spinners@^0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.10.4.tgz#3789086f3c1289d904163517dfa240e13ffd460c"
+  integrity sha512-WRzHTHjx1nvMzsyTXg1J8VVDYadGGeas6pzzxGk0T+dVSZpMIN9NrKV/h76SybdsU8cUp55+u9L1V1C9/oafhw==
+  dependencies:
+    "@emotion/core" "^10.0.35"
 
 react-transition-group@^4.3.0, react-transition-group@^4.4.1:
   version "4.4.1"


### PR DESCRIPTION
We can't use react-spinkit because of this problem https://github.com/vercel/next-plugins/issues/129 (old Github issue but the problem still exists)

![image](https://user-images.githubusercontent.com/636232/106979608-b2bec200-672c-11eb-9089-bdde66c0dba1.png)
