### PR TITLE
Fix off-by-one error in data processing

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -242,10 +242,7 @@ export async function loadData(
             file.level = 'Unknown';
         }
 
-        file.WPAtlas =
-            atlasMap[
-                `hta${Number(file.atlasid.split('_')[0].substring(3)) + 1}`
-            ];
+        file.WPAtlas = atlasMap[file.atlasid.split('_')[0]];
 
         const parentData = getSampleAndPatientData(
             file,


### PR DESCRIPTION
Fixes two points in https://github.com/ncihtan/htan-portal/issues/133:

"Atlas tab id does not match up with files ID"
and
"Undefined shows up in the all filters search"