### PR TITLE
Fix uppercase on files tab

### DIFF
--- a/components/FileTable.tsx
+++ b/components/FileTable.tsx
@@ -102,7 +102,7 @@ export default class FileTable extends React.Component<IFileTableProps> {
             {
                 name: 'Atlas Name',
                 selector: 'atlas.htan_name',
-                format: (file: Entity) => file.atlas.htan_name?.toUpperCase(),
+                format: (file: Entity) => file.atlas.htan_name,
                 grow: 2,
                 wrap: true,
                 sortable: true,


### PR DESCRIPTION
Was showing as e.g. HTAN VANDERBILT instead of HTAN Vanderbilt