### PR TITLE
Fix case where biospecimen has biospecimen as parent

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -198,9 +198,14 @@ function getSampleAndPatientData(
                     biospecimenByHTANBiospecimenID[HTANParentID];
                 HTANParentID = parentBioSpecimen.HTANParentID;
             }
-            return diagnosisByHTANParticipantID[HTANParentID] as
-                | Entity
-                | undefined;
+            if (!(HTANParentID in diagnosisByHTANParticipantID)) {
+                console.error(
+                    `${s.HTANBiospecimenID} does not have a HTANParentID with diagnosis information`
+                );
+                return undefined;
+            } else {
+                return diagnosisByHTANParticipantID[HTANParentID] as Entity;
+            }
         })
         .filter((f) => !!f) as Entity[];
 

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -194,7 +194,7 @@ function getSampleAndPatientData(
             // going up the tree until participant is found.
             let HTANParentID = s.HTANParentID;
             while (HTANParentID in biospecimenByHTANBiospecimenID) {
-                let parentBioSpecimen =
+                const parentBioSpecimen =
                     biospecimenByHTANBiospecimenID[HTANParentID];
                 HTANParentID = parentBioSpecimen.HTANParentID;
             }

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -189,12 +189,19 @@ function getSampleAndPatientData(
         .filter((f) => !!f) as Entity[];
 
     const diagnosis = biospecimen
-        .map(
-            (s) =>
-                diagnosisByHTANParticipantID[s.HTANParentID] as
-                    | Entity
-                    | undefined
-        )
+        .map((s) => {
+            // HTANParentID can be both participant or biospecimen, so keep
+            // going up the tree until participant is found.
+            let HTANParentID = s.HTANParentID;
+            while (HTANParentID in biospecimenByHTANBiospecimenID) {
+                let parentBioSpecimen =
+                    biospecimenByHTANBiospecimenID[HTANParentID];
+                HTANParentID = parentBioSpecimen.HTANParentID;
+            }
+            return diagnosisByHTANParticipantID[HTANParentID] as
+                | Entity
+                | undefined;
+        })
         .filter((f) => !!f) as Entity[];
 
     return { biospecimen, diagnosis };


### PR DESCRIPTION
Fix #225. HTAN Parent ID can be both participant or biospecimen. See also
https://data.humantumoratlas.org/standard/biospecimen

Hard to test right now since we removed HTAPP, but pre-removal this changed fixed it. Seems like it is the only atlas that has biospecimina as children of biospecimina