### PR TITLE
Add google analytics

### DIFF
--- a/lib/gtag.js
+++ b/lib/gtag.js
@@ -1,0 +1,17 @@
+export const GA_TRACKING_ID = 'G-N6EV8C84KY';
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+    window.gtag('config', GA_TRACKING_ID, {
+        page_path: url,
+    });
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+    window.gtag('event', action, {
+        event_category: category,
+        event_label: label,
+        value: value,
+    });
+};

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,21 @@
-import '../styles/app.scss';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import 'rc-tooltip/assets/bootstrap.css';
+import '../styles/app.scss';
+import * as gtag from '../lib/gtag';
 
 function App({ Component, pageProps }) {
+    const router = useRouter();
+    useEffect(() => {
+        const handleRouteChange = (url) => {
+            gtag.pageview(url);
+        };
+        router.events.on('routeChangeComplete', handleRouteChange);
+        return () => {
+            router.events.off('routeChangeComplete', handleRouteChange);
+        };
+    }, [router.events]);
+
     return <Component {...pageProps} />;
 }
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,36 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+import { GA_TRACKING_ID } from '../lib/gtag';
+
+export default class MyDocument extends Document {
+    render() {
+        return (
+            <Html>
+                <Head>
+                    {/* Global Site Tag (gtag.js) - Google Analytics */}
+                    <script
+                        async
+                        src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+                    />
+                    <script
+                        dangerouslySetInnerHTML={{
+                            __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', '${GA_TRACKING_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+                        }}
+                    />
+                </Head>
+                <body>
+                    <Main />
+                    <NextScript />
+                </body>
+            </Html>
+        );
+    }
+}


### PR DESCRIPTION
Add google analytics. I followed this example: https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics. Account exists in cbioportal analytics account as discussed with @ecerami 

It is not disabled for local development. But maybe that's fine. In their example they set the analytics id as env variable on vercel: https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics/lib/gtag.js#L1. For local development it's set as https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics/.env.local.example