### PR TITLE
Fix missing WUSTL cases and files

### DIFF
--- a/data/get_syn_data.py
+++ b/data/get_syn_data.py
@@ -151,10 +151,14 @@ if __name__ == '__main__':
                 record_list.append(record)
 
             # add records to atlas
-            atlas[data_schema] = {
-                                    "data_schema":data_schema,
-                                    "record_list":record_list
-            }
+            if data_schema in atlas:
+                # there are multiple metadata files for this one data type
+                atlas[data_schema]["record_list"] = atlas[data_schema]["record_list"] + record_list
+            else:
+                atlas[data_schema] = {
+                                        "data_schema":data_schema,
+                                        "record_list":record_list
+                }
 
             # add data schema to JSON if not already there
             if not data_schema in data_schemas:

--- a/data/syn_metadata.json
+++ b/data/syn_metadata.json
@@ -1,54 +1,4 @@
 {
-    "HTA11": {
-        "Demographics": {
-            "synapseId": "syn23636452",
-            "numItems": 33
-        },
-        "Diagnosis": {
-            "synapseId": "syn23636563",
-            "numItems": 33
-        },
-        "FamilyHistory": {
-            "synapseId": "syn23636595",
-            "numItems": 23
-        },
-        "FollowUp": {
-            "synapseId": "syn23636683",
-            "numItems": 64
-        },
-        "Therapy": {
-            "synapseId": "syn23636727",
-            "numItems": 33
-        },
-        "Exposure": {
-            "synapseId": "syn23662463",
-            "numItems": 33
-        },
-        "ScRNA-seqLevel2": {
-            "synapseId": "syn24828088",
-            "numItems": 85
-        },
-        "MolecularTest": {
-            "synapseId": "syn24986104",
-            "numItems": 33
-        },
-        "ScRNA-seqLevel3": {
-            "synapseId": "syn24998745",
-            "numItems": 85
-        },
-        "ScRNA-seqLevel1": {
-            "synapseId": "syn25006583",
-            "numItems": 170
-        },
-        "Biospecimen": {
-            "synapseId": "syn25126924",
-            "numItems": 103
-        },
-        "ImagingLevel2": {
-            "synapseId": "syn25165616",
-            "numItems": 30
-        }
-    },
     "HTA9": {
         "Demographics": {
             "synapseId": "syn24862574",
@@ -189,6 +139,10 @@
         "Diagnosis": {
             "synapseId": "syn25127027",
             "numItems": 21
+        },
+        "BulkRNA-seqLevel1": {
+            "synapseId": "syn25127342",
+            "numItems": 231
         }
     },
     "HTA4": {


### PR DESCRIPTION
Fix #240 #218. We only show cases for which there are associated files.
WUSTL has multiple ImagingLevel2 metadata files which wasn't being
handled by the JSON generation script.