### PR TITLE
Exclude specific HTAPP folders

### DIFF
--- a/data/htapp_release1.tsv
+++ b/data/htapp_release1.tsv
@@ -1,0 +1,11 @@
+Folder Name	Folder Synapse ID	Release Flag
+biospecimen_colon	syn25117237	Release1
+clinical_demographics_colon	syn24615241	Release1
+clinical_diagnosis_colon	syn24615244	Release1
+clinical_exposure_colon	syn24615243	Release1
+clinical_follow_up_colon	syn24615246	Release1
+clinical_molecular_test_colon	syn24860582	Release1
+clinical_therapy_colon	syn24615247	Release1
+single_cell_RNAseq_level_1_colon	syn24181385	Release1
+single_cell_RNAseq_level_2_colon	syn24181437	Release1
+single_cell_RNAseq_level_3_colon	syn24181445	Release1

--- a/data/syn_metadata.json
+++ b/data/syn_metadata.json
@@ -44,11 +44,11 @@
     "HTA11": {
         "Demographics": {
             "synapseId": "syn23636452",
-            "numItems": 36
+            "numItems": 84
         },
         "Diagnosis": {
             "synapseId": "syn23636563",
-            "numItems": 36
+            "numItems": 84
         },
         "FamilyHistory": {
             "synapseId": "syn23636595",
@@ -56,15 +56,15 @@
         },
         "FollowUp": {
             "synapseId": "syn23636683",
-            "numItems": 68
+            "numItems": 165
         },
         "Therapy": {
             "synapseId": "syn23636727",
-            "numItems": 36
+            "numItems": 84
         },
         "Exposure": {
             "synapseId": "syn23662463",
-            "numItems": 36
+            "numItems": 84
         },
         "ScRNA-seqLevel2": {
             "synapseId": "syn24828088",
@@ -84,7 +84,7 @@
         },
         "Biospecimen": {
             "synapseId": "syn25126924",
-            "numItems": 108
+            "numItems": 190
         },
         "ImagingLevel2": {
             "synapseId": "syn25165616",
@@ -259,8 +259,8 @@
             "numItems": 54
         },
         "ImagingLevel2": {
-            "synapseId": "syn25200520",
-            "numItems": 78
+            "synapseId": "syn25007022",
+            "numItems": 71
         },
         "Biospecimen": {
             "synapseId": "syn25110812",


### PR DESCRIPTION
We have a list of HTAPP folders to include for release 1. Only include
those files. Add `click` command line interface to easily
include/exclude these folders from the synapse JSON.