### PR TITLE
Add stanford atlas

### DIFF
--- a/data/get_syn_data.py
+++ b/data/get_syn_data.py
@@ -30,9 +30,7 @@ def generate_json(include_non_public_images, include_non_public_htapp_folders):
                     "HTAN HMS": "hta7",
                     "HTAN MSK": "hta8",
                     "HTAN OHSU": "hta9",
-                    # temp exclude stanford (>2K files makes portal sluggish)
-                    # also they have unknown levels
-                    # "HTAN Stanford": "hta10",
+                    "HTAN Stanford": "hta10",
                     "HTAN Vanderbilt": "hta11",
                     "HTAN WUSTL": "hta12",
                     # exclude TNPs for now

--- a/data/syn_metadata.json
+++ b/data/syn_metadata.json
@@ -424,5 +424,55 @@
             "synapseId": "syn25178503",
             "numItems": 1174
         }
+    },
+    "HTA10": {
+        "Biospecimen": {
+            "synapseId": "syn25539988",
+            "numItems": 176
+        },
+        "Demographics": {
+            "synapseId": "syn25540000",
+            "numItems": 7
+        },
+        "Diagnosis": {
+            "synapseId": "syn25540024",
+            "numItems": 7
+        },
+        "Exposure": {
+            "synapseId": "syn25540036",
+            "numItems": 7
+        },
+        "FamilyHistory": {
+            "synapseId": "syn25540048",
+            "numItems": 7
+        },
+        "FollowUp": {
+            "synapseId": "syn25540059",
+            "numItems": 7
+        },
+        "Therapy": {
+            "synapseId": "syn25540068",
+            "numItems": 7
+        },
+        "BulkRNA-seqLevel1": {
+            "synapseId": "syn25540138",
+            "numItems": 338
+        },
+        "BulkDNALevel1": {
+            "synapseId": "syn25540165",
+            "numItems": 108
+        },
+        "ScRNA-seqLevel1": {
+            "synapseId": "syn25540295",
+            "numItems": 222
+        },
+        "ScATAC-seqLevel1": {
+            "synapseId": "syn25540307",
+            "numItems": 384
+        },
+        "OtherAssay": {
+            "synapseId": "syn25540340",
+            "numItems": 393
+        }
     }
 }

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -211,12 +211,15 @@ function getSampleAndPatientData(
             : [file];
 
     const biospecimen = primaryParents
-        .map(
-            (p) =>
-                biospecimenByHTANBiospecimenID[p.HTANParentBiospecimenID] as
-                    | Entity
-                    | undefined
+        .map((p) =>
+            p.HTANParentBiospecimenID.split(',').map(
+                (HTANParentBiospecimenID) =>
+                    biospecimenByHTANBiospecimenID[HTANParentBiospecimenID] as
+                        | Entity
+                        | undefined
+            )
         )
+        .flat()
         .filter((f) => !!f) as Entity[];
 
     const diagnosis = getCaseData(
@@ -329,9 +332,9 @@ export function processSynapseJSON(synapseJson: any, WPAtlasData: WPAtlas[]) {
             // special case for Other Assay.  These are assays that don't fit
             // the standard model.  To have a more descriptive name use assay
             // type field instead
-            if (parsedAssay.name === "Other Assay") {
+            if (parsedAssay.name === 'Other Assay') {
                 file.assayName = file.AssayType || 'Other Assay';
-                file.level = 'Other'
+                file.level = 'Other';
             }
         } else {
             file.level = 'Unknown';


### PR DESCRIPTION
Fix issues:

- rename all database results to original assay name:

    ```
    python get_syn_data.py && gsed -i 's/"Database Search Result"/"LC-MS3"/g' ../public/syn_data.json && gsed -i 's/"Protein Database"/"LC-MS3"/g' ../public/syn_data.json
    ```
- handle bug when level 1 file is comma separated (has multiple
biospecimen parents)