### PR TITLE
Update HTAN assets for Release 2

### DIFF
--- a/data/htan-imaging-assets.json
+++ b/data/htan-imaging-assets.json
@@ -794,27 +794,113 @@
   },
   {
     "synid": "syn25074974",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25074976",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25074996",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075278",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075282",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075311",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075365",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25075398",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075400",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075411",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075415",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075429",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075431",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25075475",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075484",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25075487",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/big_panini/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/nasty_ekeblad/thumbnail.png"
   },
   {
+    "synid": "syn25075505",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075516",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/thumbnail.png"
+  },
+  {
     "synid": "syn25075529",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25075561",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075587",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25075636",
@@ -831,24 +917,124 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/thumbnail.png"
   },
   {
+    "synid": "syn25075782",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075869",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/thumbnail.png"
+  },
+  {
     "synid": "syn25075875",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075901",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075912",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075926",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075948",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25076001",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076004",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076014",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076021",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25076038",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076062",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25076096",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076108",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076147",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25076156",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076184",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076268",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076369",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25076441",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076572",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076608",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076711",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/thumbnail.png"
   },
   {
     "synid": "syn25077585",
@@ -949,16 +1135,43 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/thumbnail.png"
   },
   {
+    "synid": "syn25114909",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25115882",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25117091",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25547793",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/naughty_rubens/minerva/index.html"
+  },
+  {
     "synid": "syn25547794",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html"
+  },
+  {
+    "synid": "syn25547801",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/naughty_rubens/minerva/index.html"
   },
   {
     "synid": "syn25547815",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547815/nasty_ekeblad/thumbnail.png"
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547815/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25547818",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/naughty_rubens/minerva/index.html"
   },
   {
     "synid": "syn25547827",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/nasty_ekeblad/thumbnail.png"
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/big_panini/thumbnail.png"
   },
   {
     "synid": "syn25665299",
@@ -1428,16 +1641,53 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/thumbnail.png"
   },
   {
+    "synid": "syn25871039",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/naughty_rubens/minerva/index.html"
+  },
+  {
+    "synid": "syn25871042",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html"
+  },
+  {
+    "synid": "syn25871070",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/naughty_rubens/minerva/index.html"
+  },
+  {
     "synid": "syn25871072",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/nasty_ekeblad/thumbnail.png"
   },
   {
     "synid": "syn25871073",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/naughty_rubens/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/big_panini/thumbnail.png"
   },
   {
     "synid": "syn25871082",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/naughty_rubens/minerva/index.html"
+  },
+  {
+    "synid": "syn25871084",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25871118",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25871148",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/naughty_rubens/minerva/index.html"
+  },
+  {
+    "synid": "syn25883274",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn25883395",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn25883405",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26344274",
@@ -1806,7 +2056,7 @@
   },
   {
     "synid": "syn26452512",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452512/v1/thumbnail.png"
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452512/golden_leavitt/thumbnail.png"
   },
   {
     "synid": "syn26452513",
@@ -1829,68 +2079,1195 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/thumbnail.png"
   },
   {
+    "synid": "syn26466814",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466814/golden_leavitt/thumbnail.png"
+  },
+  {
+    "synid": "syn26466819",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466819/golden_leavitt/thumbnail.png"
+  },
+  {
+    "synid": "syn26466822",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466822/golden_leavitt/thumbnail.png"
+  },
+  {
+    "synid": "syn26486747",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486749",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486751",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486754",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486755",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486757",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486759",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486771",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486773",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486775",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486777",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486779",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486781",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/thumbnail.png"
+  },
+  {
     "synid": "syn26486783",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486785",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486787",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486789",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486791",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486793",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/thumbnail.png"
   },
   {
     "synid": "syn26529076",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/nasty_ekeblad/thumbnail.png"
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26643894",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn26643896",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn26644414",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644416",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644421",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644422",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644423",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644426",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644427",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644428",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644429",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644430",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644431",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644432",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644433",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644434",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644435",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644436",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644437",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644438",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26644439",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26644440",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644441",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644442",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644443",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644444",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644445",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644446",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644447",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644448",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644449",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644450",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644451",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644452",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644453",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644454",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26644455",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644456",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644457",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644458",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/naughty_torricelli/minerva/index.html"
   },
   {
     "synid": "syn26644459",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644460",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644461",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644462",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644463",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644464",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644465",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644466",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644467",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644468",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644469",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644470",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644471",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644472",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644473",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644474",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644475",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644476",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644477",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644478",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644479",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644481",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26644482",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644483",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644484",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644485",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644486",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644487",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644488",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644489",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644490",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26644491",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644492",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644493",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26644494",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644495",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644496",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644497",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644498",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644499",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644500",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644501",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644502",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644503",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644504",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644505",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644506",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644507",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644508",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644509",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644510",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644511",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644512",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644513",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644514",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644515",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644516",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644517",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644518",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644519",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644520",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644521",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644522",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644523",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644524",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644525",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644526",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644527",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644528",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644529",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644530",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644531",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644532",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644533",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644534",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26644535",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644536",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644537",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644538",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644539",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644540",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644541",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644542",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644543",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/thumbnail.png"
   },
   {
     "synid": "syn26644544",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644545",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644546",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644547",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644548",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644549",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644550",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644551",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644552",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/naughty_torricelli/minerva/index.html"
   },
   {
     "synid": "syn26644553",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/big_panini/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/nasty_ekeblad/thumbnail.png"
   },
   {
+    "synid": "syn26644554",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644555",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644556",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644557",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644558",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644559",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644560",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644561",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644562",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644563",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644564",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644565",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644566",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644567",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644568",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644569",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644570",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644571",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644572",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644573",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644574",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644575",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644576",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644577",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644578",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644579",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644580",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/thumbnail.png"
+  },
+  {
     "synid": "syn26644581",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644582",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644583",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644584",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644585",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644586",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644587",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644588",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644589",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644590",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644591",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644592",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644593",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644594",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644595",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644596",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644597",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644598",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644599",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644600",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644601",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644602",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644603",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644604",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644605",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644606",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn26644607",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/naughty_torricelli/minerva/index.html"
   },
   {
     "synid": "syn26644608",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644609",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644610",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644611",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644612",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/naughty_torricelli/minerva/index.html"
   },
   {
     "synid": "syn26644613",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644614",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644615",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644616",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644617",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644618",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644619",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644620",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644621",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644622",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/naughty_torricelli/minerva/index.html"
   },
   {
     "synid": "syn26644625",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644626",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644627",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644628",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644629",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644630",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644631",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644632",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644633",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644634",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644635",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644636",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644637",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644638",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644639",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644640",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644641",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644642",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644643",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644644",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644645",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644646",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644647",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644648",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644649",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/naughty_torricelli/minerva/index.html"
+  },
+  {
+    "synid": "syn26644650",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644651",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/marvelous_goldstine/thumbnail.png"
   },
   {
     "synid": "syn26644652",
@@ -1898,27 +3275,1268 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/nasty_ekeblad/thumbnail.png"
   },
   {
+    "synid": "syn26644653",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644654",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644655",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644656",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644657",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644658",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644659",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644660",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644661",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/marvelous_goldstine/thumbnail.png"
+  },
+  {
     "synid": "syn26644662",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644663",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644664",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644665",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644666",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644667",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/marvelous_goldstine/thumbnail.png"
   },
   {
     "synid": "syn26644668",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644669",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644670",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644671",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644672",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644673",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644674",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644675",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644676",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644677",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644678",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644679",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644680",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644681",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644682",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644683",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644684",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644685",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644686",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644687",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644688",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644689",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644690",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/marvelous_goldstine/thumbnail.png"
   },
   {
     "synid": "syn26644691",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644692",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/marvelous_goldstine/thumbnail.png"
   },
   {
     "synid": "syn26644693",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644694",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644695",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644696",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/marvelous_goldstine/thumbnail.png"
   },
   {
     "synid": "syn26644697",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/nasty_ekeblad/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644698",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644699",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644700",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644701",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644702",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644703",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644704",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644705",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644706",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644707",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644708",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644709",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644710",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644711",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644712",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644713",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/marvelous_goldstine/thumbnail.png"
   },
   {
     "synid": "syn26644714",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/nasty_ekeblad/thumbnail.png"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644715",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644716",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644717",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644718",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644719",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644720",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644721",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644722",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644723",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644724",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644725",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644726",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644727",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644728",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644729",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644730",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644731",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644732",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644733",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644734",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644735",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644736",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644737",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644738",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644739",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644740",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644741",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644742",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644743",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644744",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644745",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644746",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644747",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644748",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644749",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26644750",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/marvelous_goldstine/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/marvelous_goldstine/thumbnail.png"
+  },
+  {
+    "synid": "syn26937643",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937644",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937645",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937646",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937647",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937648",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937649",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937650",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937651",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937652",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937653",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937654",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937655",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937656",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937657",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937658",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937659",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937660",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937661",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937662",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937663",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937664",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937665",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937666",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937667",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937668",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937669",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937670",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937671",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937672",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937673",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937674",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937675",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937676",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937677",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937678",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937679",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937680",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937681",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937696",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937697",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937730",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937748",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937756",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937757",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937758",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937759",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937760",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937761",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937762",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937763",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937764",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937765",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937766",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937767",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937768",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937769",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937770",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937771",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937772",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937773",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937774",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937775",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937776",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937777",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937778",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937779",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937780",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937781",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937782",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937783",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937784",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937785",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937786",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937787",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937788",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937789",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937790",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937791",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937792",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937793",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937802",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937803",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937804",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937836",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937859",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937860",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937861",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937862",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937863",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937864",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937865",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937866",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937867",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937868",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937869",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937870",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937871",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937872",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937873",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937874",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937875",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937876",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937877",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937878",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937879",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937880",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937881",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937882",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937883",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937884",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937885",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937886",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937887",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937888",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937889",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937890",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937891",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937892",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937893",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937894",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937895",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937896",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937911",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937912",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937950",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937969",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937971",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937972",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937973",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937974",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937975",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937976",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937977",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937978",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937979",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937980",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937981",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937982",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937983",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937984",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937985",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937986",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937987",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937988",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937989",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937990",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937991",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937992",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937994",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937995",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937997",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937999",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26938001",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26940250",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/magical_cori/thumbnail.png"
   }
 ]


### PR DESCRIPTION
Updates `data/htan-imaging-assets.json` to include initial assets for release 2