### PR TITLE
Include TNP Sardana in get_syn_data script

### DIFF
--- a/data/get_syn_data.py
+++ b/data/get_syn_data.py
@@ -41,7 +41,7 @@ def generate_json(include_at_risk_populations, include_released_only):
                     "HTAN Vanderbilt": "hta11",
                     "HTAN WUSTL": "hta12",
                     # exclude TNPs for now
-                    # "HTAN TNP SARDANA": "hta13",
+                    "HTAN TNP SARDANA": "hta13",
                     # "HTAN TNP - TMA": "hta14"
     }
 


### PR DESCRIPTION
Per email from HMS, SARDAN's data is not listed on the portal. This PR adds them (back) into the get_syn_data script