### PR TITLE
Remove "Level" dropdown on explore page

### DIFF
--- a/components/FileTable.tsx
+++ b/components/FileTable.tsx
@@ -425,6 +425,7 @@ interface IFileTableProps {
     entities: Entity[];
     getGroupsByPropertyFiltered: any;
     patientCount: number;
+    enableLevelFilter?: boolean; // Add or hide "Level" filter above table
 }
 
 @observer
@@ -898,9 +899,11 @@ export default class FileTable extends React.Component<IFileTableProps> {
     }
 
     @computed get filteredEntities() {
-        return _.chain(this.props.entities)
-            .filter((e) => this.selectedLevels.includes(e.level))
-            .value();
+        return this.props.enableLevelFilter
+            ? _.chain(this.props.entities)
+                  .filter((e) => this.selectedLevels.includes(e.level))
+                  .value()
+            : this.props.entities;
     }
 
     constructor(props: IFileTableProps) {
@@ -1002,11 +1005,13 @@ export default class FileTable extends React.Component<IFileTableProps> {
                         </button>
                     }
                     extraControlsInsideDataTableControls={
-                        <LevelSelect
-                            allLevels={this.allLevels}
-                            selectedLevels={this.selectedLevels}
-                            onLevelToggled={this.setSelectedLevels}
-                        />
+                        this.props.enableLevelFilter ? (
+                            <LevelSelect
+                                allLevels={this.allLevels}
+                                selectedLevels={this.selectedLevels}
+                                onLevelToggled={this.setSelectedLevels}
+                            />
+                        ) : undefined
                     }
                     paginationServerOptions={{
                         persistSelectedOnPageChange: false,

--- a/components/PublicationTabs.tsx
+++ b/components/PublicationTabs.tsx
@@ -466,6 +466,7 @@ const PublicationTabs: React.FunctionComponent<IPublicationTabsProps> = observer
                                         props.assays[assayName]
                                     )}
                                     patientCount={props.cases.length}
+                                    enableLevelFilter={true}
                                 />
                             </div>
                         );


### PR DESCRIPTION
Fix: https://github.com/ncihtan/htan-portal/issues/432
Remove "Level" dropdown on explore page
Test:
Old: 
https://htan-portal-nextjs-git-fork-leexgh-level-filter-htan.vercel.app/explore?selectedFilters=%5B%7B%22group%22%3A%22AtlasName%22%2C%22value%22%3A%22HTAN+HMS%22%7D%5D&tab=file
New: 
https://htan-portal-nextjs-git-fork-leexgh-fix-level-filter-htan.vercel.app/explore?selectedFilters=%5B%7B%22group%22%3A%22AtlasName%22%2C%22value%22%3A%22HTAN+HMS%22%7D%5D&tab=file