### PR TITLE
Keep default order of required dependencies for explore page table columns

### DIFF
--- a/lib/dataSchemaHelpers.ts
+++ b/lib/dataSchemaHelpers.ts
@@ -228,7 +228,7 @@ export function getExclusiveDependencyIds(
     schema: DataSchemaData,
     schemaDataById: SchemaDataById = {}
 ) {
-    // sort dependencies alphabetically without changing the original order
+    // sort both required and conditional dependencies alphabetically
     const requiredDependencies = sortDependenciesByAttribute(
         schema.requiredDependencies,
         schemaDataById
@@ -245,17 +245,23 @@ export function getExclusiveDependencyIds(
  */
 export function getAllDependencyIds(
     schema: DataSchemaData,
-    schemaDataById: SchemaDataById = {}
+    schemaDataById: SchemaDataById = {},
+    keepDefaultOrderOfRequiredDependencies: boolean = true
 ) {
-    // sort dependencies alphabetically without changing the original order
-    const requiredDependencies = sortDependenciesByAttribute(
-        schema.requiredDependencies,
-        schemaDataById
-    );
+    // sort required dependencies alphabetically if needed
+    const requiredDependencies = keepDefaultOrderOfRequiredDependencies
+        ? schema.requiredDependencies
+        : sortDependenciesByAttribute(
+              schema.requiredDependencies,
+              schemaDataById
+          );
+
+    // sort conditional dependencies alphabetically
     const conditionalDependencies = sortDependenciesByAttribute(
         schema.conditionalDependencies,
         schemaDataById
     );
+
     return _.uniq([...requiredDependencies, ...conditionalDependencies]);
 }
 


### PR DESCRIPTION
We want the dependencies ordered alphabetically for the Data Standards page, but keep the default order for the Explore page table columns.