### PR TITLE
Update assets to included fixed HTAPP H&E images

### DIFF
--- a/data/htan-imaging-assets.json
+++ b/data/htan-imaging-assets.json
@@ -1924,53 +1924,53 @@
   },
   {
     "synid": "syn25882267",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882268",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882269",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882270",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882273",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882275",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882276",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882277",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882282",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882289",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/confident_shaw_3/thumbnail.jpg"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/thumbnail.jpg"
   },
   {
     "synid": "syn25882315",

--- a/data/htan-imaging-assets.json
+++ b/data/htan-imaging-assets.json
@@ -8059,7 +8059,8 @@
   },
   {
     "synid": "syn27393133",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393138",
@@ -8071,11 +8072,13 @@
   },
   {
     "synid": "syn27393178",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393191",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393199",
@@ -8115,11 +8118,13 @@
   },
   {
     "synid": "syn27393223",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393234",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393239",
@@ -8143,7 +8148,8 @@
   },
   {
     "synid": "syn27393256",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393258",
@@ -8183,7 +8189,8 @@
   },
   {
     "synid": "syn27393281",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393284",
@@ -8215,11 +8222,13 @@
   },
   {
     "synid": "syn27393304",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393306",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393760",
@@ -8235,7 +8244,8 @@
   },
   {
     "synid": "syn27393767",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393769",
@@ -8243,7 +8253,8 @@
   },
   {
     "synid": "syn27393772",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393773",
@@ -8295,7 +8306,8 @@
   },
   {
     "synid": "syn27393790",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/v1/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/sad_poitras_2/thumbnail.jpg"
   },
   {
     "synid": "syn27393792",


### PR DESCRIPTION
HTAPP H&E thumbnails and minerva stories had a bright pink background due to the PhotometricInterpretation tag not being set to RGB. This is fixed here.

Also add a few WASHU H&E thumbnails that are missing (still more to do!)