### PR TITLE
Add minerva thumbnails

### DIFF
--- a/data/htan-imaging-assets.json
+++ b/data/htan-imaging-assets.json
@@ -1090,15 +1090,18 @@
   },
   {
     "synid": "syn25547794",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
   },
   {
     "synid": "syn25547796",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547797",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547798",
@@ -1107,15 +1110,18 @@
   },
   {
     "synid": "syn25547800",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547801",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547802",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547803",
@@ -1142,7 +1148,8 @@
   },
   {
     "synid": "syn25547811",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547812",
@@ -1151,7 +1158,8 @@
   },
   {
     "synid": "syn25547814",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547815",
@@ -1182,7 +1190,8 @@
   },
   {
     "synid": "syn25547821",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547822",
@@ -1191,11 +1200,13 @@
   },
   {
     "synid": "syn25547823",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547824",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547825",
@@ -1204,7 +1215,8 @@
   },
   {
     "synid": "syn25547826",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25547827",
@@ -1609,15 +1621,18 @@
   },
   {
     "synid": "syn25871033",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871034",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871035",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871036",
@@ -1625,31 +1640,38 @@
   },
   {
     "synid": "syn25871037",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871038",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871039",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871040",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871042",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
   },
   {
     "synid": "syn25871043",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871046",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871048",
@@ -1666,7 +1688,8 @@
   },
   {
     "synid": "syn25871056",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871061",
@@ -1685,7 +1708,8 @@
   },
   {
     "synid": "syn25871070",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871071",
@@ -1729,7 +1753,8 @@
   },
   {
     "synid": "syn25871080",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871081",
@@ -1753,11 +1778,13 @@
   },
   {
     "synid": "syn25871085",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871086",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871087",
@@ -1765,23 +1792,28 @@
   },
   {
     "synid": "syn25871089",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871090",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871091",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871092",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871093",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871094",
@@ -1790,35 +1822,43 @@
   },
   {
     "synid": "syn25871096",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871097",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871098",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871099",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871100",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871101",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871114",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871117",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871118",
@@ -1827,15 +1867,18 @@
   },
   {
     "synid": "syn25871119",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871121",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871122",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871123",
@@ -1844,11 +1887,13 @@
   },
   {
     "synid": "syn25871124",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871125",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871126",
@@ -1857,11 +1902,13 @@
   },
   {
     "synid": "syn25871129",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871130",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871132",
@@ -1870,27 +1917,33 @@
   },
   {
     "synid": "syn25871133",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871139",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871140",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871143",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871147",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25871148",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/index.html"
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn25874083",
@@ -7616,571 +7669,6 @@
     "synid": "syn27393799",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/v1/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn28564179",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564180",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564188",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564193",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564197",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564201",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564202",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564204",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564205",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564208",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564212",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564213",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564216",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564220",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564221",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564226",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564227",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564230",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564232",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564233",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564234",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564239",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564242",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564251",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564253",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564269",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564270",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564275",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564279",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564284",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564301",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564306",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564330",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564350",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564376",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564381",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564393",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564441",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564494",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564516",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564520",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564528",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564538",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564542",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564549",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564552",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564554",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564566",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564569",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564581",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564584",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564585",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564602",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564608",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564611",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564614",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564616",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564621",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564625",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564630",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564644",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564645",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564649",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564658",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564664",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564666",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564671",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564675",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564677",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564693",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564694",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564702",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564703",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564705",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564712",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn25547794",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547796",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547797",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547800",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547801",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547802",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547811",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547814",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547821",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547823",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547824",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25547826",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871033",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871034",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871035",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871037",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871038",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871039",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871040",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871042",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871043",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871046",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871056",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871070",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871080",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871085",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871086",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871089",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871090",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871091",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871092",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871093",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871096",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871097",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871098",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871099",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871100",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871101",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871114",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871117",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871119",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871121",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871122",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871124",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871125",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871129",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871130",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871133",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871139",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871140",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871143",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871147",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-  },
-  {
-    "synid": "syn25871148",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
   },
   {
     "synid": "syn28564179",

--- a/data/htan-imaging-assets.json
+++ b/data/htan-imaging-assets.json
@@ -1,7920 +1,9692 @@
 [
-  {
-    "synid": "syn24829425",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829425/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829425/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829426",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829426/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829426/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829428",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829428/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829428/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829429",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829429/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829429/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829430",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829430/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829430/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829431",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829431/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829431/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829432",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829432/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829432/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829433",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829433/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829433/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829434",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829434/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829434/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829435",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829435/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829435/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829436",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829436/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829436/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829437",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829437/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829437/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829438",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829438/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829438/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829439",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829439/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829439/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829440",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829440/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829440/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829441",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829441/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829441/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829442",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829442/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829442/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829443",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829443/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829443/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829444",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829444/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829444/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829445",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829445/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829445/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829446",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829446/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829446/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829447",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829447/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829447/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829448",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829448/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829448/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829449",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829449/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829449/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829450",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829450/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829450/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829451",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829451/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829451/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829452",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829452/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829452/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829453",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829453/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829453/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829454",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829454/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829454/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829455",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829455/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829455/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829456",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829456/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829456/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829457",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829457/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829457/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829458",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829458/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829458/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829459",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829459/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829459/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829460",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829460/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829460/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829461",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829461/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829461/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829462",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829462/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829462/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn24829463",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829463/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829463/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829464",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829464/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829464/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829465",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829465/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829465/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829466",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829466/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829466/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829467",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829467/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829467/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829468",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829468/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829468/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829469",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829469/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829469/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829470",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829470/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829470/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829471",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829471/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829471/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829472",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829472/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829472/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829473",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829473/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829473/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829474",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829474/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829474/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829475",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829475/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829475/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829476",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829476/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829476/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829477",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829477/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829477/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829478",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829478/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829478/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829479",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829479/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829479/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829480",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829480/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829480/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829481",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829481/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829481/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829482",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829482/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829482/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829483",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829483/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829483/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829484",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829484/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829484/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24829485",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829485/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829485/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24986807",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24986807/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24986807/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992967",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992967/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992968",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992968/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992969",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992969/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992970",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992970/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992971",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992971/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992973",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992973/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992974",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992974/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992975",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992975/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992977",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992977/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992978",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992978/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992979",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992979/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992980",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992980/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992981",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992981/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992982",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992982/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992983",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992983/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992984",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992984/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992985",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992985/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992986",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992986/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992987",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992987/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992988",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992988/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992989",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992989/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992990",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992990/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992991",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992991/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992992",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992992/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992993",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992993/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992994",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992994/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992996",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992996/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992997",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992997/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992998",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992998/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24992999",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992999/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993000",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993000/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993001",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993001/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993002",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993002/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993003",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993003/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993005",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993005/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993007",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993007/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993008",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993008/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993009",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993009/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993010",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993010/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993011",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993011/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993012",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993012/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993013",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993013/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993014",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993014/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993016",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993016/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993017",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993017/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993018",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993018/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993019",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993019/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993020",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993020/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993021",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993021/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993022",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993022/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993023",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993023/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993024",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993024/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993025",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993025/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993026",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993026/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993027",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993027/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993029",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993029/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993031",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993031/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993032",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993032/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993033",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993033/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993034",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993034/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993035",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993035/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993036",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993036/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993037",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993037/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993039",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993039/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993040",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993040/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993046",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993046/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993048",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993048/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993050",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993050/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993057",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993057/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993063",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993063/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn24993069",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993069/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25054776",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25054776/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25054776/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25055566",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055566/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055566/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25055737",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055737/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055737/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25055797",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055797/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055797/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25056191",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056191/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056191/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25056480",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056480/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056480/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25056808",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056808/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056808/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25057095",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057095/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057095/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25057262",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057262/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057262/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25058438",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25058438/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25058438/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25059248",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059248/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059248/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25059795",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059795/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059795/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25059811",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059811/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059811/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25060020",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060020/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060020/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25060047",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060047/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060047/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25060077",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060077/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060077/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25068083",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25068083/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25068083/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25070310",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070310/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070310/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25070644",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070644/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070644/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25071129",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071129/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071129/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25071714",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071714/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071714/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25071769",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071769/elated_poisson/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071769/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25071777",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071777/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071777/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25072720",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25072720/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25072779",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25072779/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25073076",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25073076/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25073076/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25074523",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074523/nasty_ekeblad/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074523/nasty_ekeblad/thumbnail.png"
-  },
-  {
-    "synid": "syn25074974",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25074976",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25074996",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075278",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075282",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075311",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075365",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075398",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075400",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075411",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075415",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075429",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075431",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075475",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075480",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075484",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075487",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/big_panini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/nasty_ekeblad/thumbnail.png"
-  },
-  {
-    "synid": "syn25075505",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075516",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075529",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075561",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075587",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075636",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075636/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25075664",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075664/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075664/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25075713",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25075782",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075869",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075875",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075901",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075912",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075926",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25075948",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076001",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076004",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076014",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076021",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076038",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076062",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076096",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076108",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076147",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076156",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076184",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076268",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076369",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/thumbnail.png"
-  },
-  {
-    "synid": "syn25076441",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076572",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076608",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25076711",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25077585",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077585/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077585/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077641",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077641/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077641/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077680",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077680/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077680/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077727",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077727/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077727/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077777",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077777/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077839",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077839/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077877",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077877/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077877/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077900",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077900/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077900/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077940",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077940/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077940/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25077960",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077960/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077960/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25078332",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25078332/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25078512",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25078512/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25079158",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25079158/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25079158/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25080543",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080543/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080543/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25080595",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080595/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25080720",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080720/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080720/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25081236",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081236/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25081468",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081468/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081468/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25082605",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25082605/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25083176",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083176/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083176/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25083552",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25114909",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25115882",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25117091",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn25547790",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547790/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547790/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547793",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547794",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html"
-  },
-  {
-    "synid": "syn25547796",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547797",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547798",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547798/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547798/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547800",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547801",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547802",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547803",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547803/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547803/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547805",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547805/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547805/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547806",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547806/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547806/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547808",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547808/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547809",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547809/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547811",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547812",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547812/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547812/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547814",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547815",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547815/big_panini/thumbnail.png"
-  },
-  {
-    "synid": "syn25547816",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547816/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547817",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547817/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547817/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547818",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/naughty_rubens/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547819",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547819/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547819/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547820",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547820/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547821",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547822",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547822/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547822/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547823",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547824",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547825",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547825/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547825/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547826",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25547827",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25547828",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547828/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25665299",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665299/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665299/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25665424",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665424/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665424/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25665553",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665553/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665553/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25665640",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665640/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665640/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25665766",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665766/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665766/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25665870",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665870/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665870/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666058",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666058/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666058/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666170",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666170/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666170/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666276",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666276/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666276/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666409",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666409/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666409/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666476",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666476/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666476/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666622",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666622/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666622/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666713",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666713/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666713/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666775",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666775/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666775/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25666862",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666862/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666862/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701019",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701019/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701020",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701020/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701023",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701023/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701025",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701025/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701026",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701026/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701030",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701030/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701033",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701033/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701036",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701036/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701038",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701038/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701040",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701040/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701043",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701043/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701044",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701044/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701046",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701046/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701048",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701048/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701050",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701050/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701052",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701052/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701055",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701055/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701056",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701056/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701058",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701058/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701060",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701060/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701064",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701064/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701066",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701066/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701069",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701069/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701071",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701071/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701073",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701073/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701077",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701077/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701078",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701078/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701081",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701081/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701083",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701083/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701085",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701085/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701087",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701087/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701089",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701089/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701092",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701092/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701094",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701094/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701097",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701097/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701100",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701100/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701102",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701102/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701104",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701104/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701106",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701106/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701108",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701108/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701110",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701110/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701112",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701112/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701114",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701114/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701116",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701116/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25701118",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701118/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701120",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701120/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701122",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701122/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701126",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701126/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701128",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701128/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701131",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701131/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701133",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701133/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701136",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701136/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701140",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701140/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701142",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701142/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701145",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701145/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701146",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701146/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701149",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701149/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701151",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701151/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701154",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701154/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701156",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701156/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701159",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701159/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25701162",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701162/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701164",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701164/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701166",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701166/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701168",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701168/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701170",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701170/stoic_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25701172",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701172/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701174",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701174/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701176",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701176/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701179",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701179/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701180",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701180/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701182",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701182/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701184",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701184/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701188",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701188/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701190",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701190/kickass_mirzakhani/thumbnail.png"
-  },
-  {
-    "synid": "syn25701193",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701193/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701195",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701195/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25701198",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701198/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25757216",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn25871033",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871034",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871035",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871036",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871036/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871037",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871038",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871039",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871040",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871042",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html"
-  },
-  {
-    "synid": "syn25871043",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871046",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871048",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871048/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871048/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871049",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871049/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871052",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871052/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871056",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871061",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871061/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871061/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871063",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871063/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871063/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871069",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871069/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871069/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871070",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871071",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871071/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871071/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871072",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871073",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/naughty_rubens/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/big_panini/thumbnail.png"
-  },
-  {
-    "synid": "syn25871074",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871074/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871074/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871075",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871075/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871075/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871076",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871076/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871076/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871078",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871078/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871078/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871079",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871079/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871079/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871080",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871081",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871081/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871081/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871082",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871083",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871083/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871083/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871084",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/big_panini/thumbnail.png"
-  },
-  {
-    "synid": "syn25871085",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871086",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871087",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871087/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871089",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871090",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871091",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871092",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871093",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871094",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871094/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871094/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871096",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871097",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871098",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871099",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871100",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871101",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871114",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871117",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871118",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/big_panini/thumbnail.png"
-  },
-  {
-    "synid": "syn25871119",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871121",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871122",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871123",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871123/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871123/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871124",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871125",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871126",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871126/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871126/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871129",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871130",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871132",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871132/loving_swartz_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871132/loving_swartz_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25871133",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871139",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871140",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871143",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871147",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25871148",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/index.html"
-  },
-  {
-    "synid": "syn25874083",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874083/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874083/confident_shaw_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25874084",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874084/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874084/confident_shaw_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25874088",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874088/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874088/confident_shaw_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25874089",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874089/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874089/confident_shaw_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25874099",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874099/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874099/confident_shaw_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25874101",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874101/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874101/confident_shaw_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882267",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882268",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882269",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882270",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882273",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882275",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882276",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882277",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882282",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882289",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882315",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882315/confident_shaw_3/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882315/confident_shaw_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn25882965",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882965/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882965/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25882990",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882990/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882990/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883086",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883086/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883086/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883126",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883126/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883126/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883141",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883141/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883141/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883160",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883160/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883160/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883246",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883246/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883246/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883274",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883295",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883295/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883295/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883318",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883318/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883318/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883326",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883326/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883326/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883365",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883365/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883365/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883382",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883382/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883382/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883391",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883391/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883391/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883395",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883405",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883416",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883416/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883416/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25883433",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883433/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883433/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn25884288",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25884288/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25884288/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26344274",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344274/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344274/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344275",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344275/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344275/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344276",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344276/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344276/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344277",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344277/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344277/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344278",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344278/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344278/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344279",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344279/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344279/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344280",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344280/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344280/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344281",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344281/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344281/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344282",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344282/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344282/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344283",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344283/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344283/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344284",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344284/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344284/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344285",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344285/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344285/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344286",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344286/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344286/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344287",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344287/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344287/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344288",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344288/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344288/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344289",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344289/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344289/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344290",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344290/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344290/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344291",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344291/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344291/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344292",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344292/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344292/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344293",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344293/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344293/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344294",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344294/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344294/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344295",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344295/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344295/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344296",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344296/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344296/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344297",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344297/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344297/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344298",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344298/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344298/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344299",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344299/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344299/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344300",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344300/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344300/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344301",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344301/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344301/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344302",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344302/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344302/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344303",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344303/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344303/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344304",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344304/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344304/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344305",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344305/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344305/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344306",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344306/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344306/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344307",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344307/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344307/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344308",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344308/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344308/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344309",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344309/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344309/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344310",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344310/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344310/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344311",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344311/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344311/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344312",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344312/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344312/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344313",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344313/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344313/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344314",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344314/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344314/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344315",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344315/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344315/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344316",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344316/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344316/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344317",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344317/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344317/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344318",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344318/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344318/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344319",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344319/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344319/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344320",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344320/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344320/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344321",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344321/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344321/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344322",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344322/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344322/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344323",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344323/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344323/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344324",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344324/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344324/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344325",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344325/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344325/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344326",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344326/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344326/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344327",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344327/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344327/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344328",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344328/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344328/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344329",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344329/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344329/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344330",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344330/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344330/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26344331",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344331/hungry_montalcini/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344331/hungry_montalcini/thumbnail.png"
-  },
-  {
-    "synid": "syn26445552",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445552/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445552/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26445553",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445553/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445553/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26445554",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445554/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445554/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26445555",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445555/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445555/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26445556",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445556/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445556/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26445557",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445557/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445557/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26445558",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445558/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445558/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26445559",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445559/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445559/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452482",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452482/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452482/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452504",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452504/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452504/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452505",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452505/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452505/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452508",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452508/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452508/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452509",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452509/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452509/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452510",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452510/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452510/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452511",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452511/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452511/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452512",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452512/golden_leavitt/thumbnail.png"
-  },
-  {
-    "synid": "syn26452513",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452513/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452513/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452523",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452523/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452523/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452527",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452527/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452527/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26452529",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/thumbnail.png"
-  },
-  {
-    "synid": "syn26466814",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466814/golden_leavitt/thumbnail.png"
-  },
-  {
-    "synid": "syn26466819",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466819/golden_leavitt/thumbnail.png"
-  },
-  {
-    "synid": "syn26466822",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466822/golden_leavitt/thumbnail.png"
-  },
-  {
-    "synid": "syn26486747",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486749",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486751",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486754",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486755",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486757",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486759",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486771",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486773",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486775",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486777",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486779",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486781",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486783",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486785",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486787",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486789",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486791",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26486793",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/thumbnail.png"
-  },
-  {
-    "synid": "syn26529074",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529074/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529074/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26529076",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26535446",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535446/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535446/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535455",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535455/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535455/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535456",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535456/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535456/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535472",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535472/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535472/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535474",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535474/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535474/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535475",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535475/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535475/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535479",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535479/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535479/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535480",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535480/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535480/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535481",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535481/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535481/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535483",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535483/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535483/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535495",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535495/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535495/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535498",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535498/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535498/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535499",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535499/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535499/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535516",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535516/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535516/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535526",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535526/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535526/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535533",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535533/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535533/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535552",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535552/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535552/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535554",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535554/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535554/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535557",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535557/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535557/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535559",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535559/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535559/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535567",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535567/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535567/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535569",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535569/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535569/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535570",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535570/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535570/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535573",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535573/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535573/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535575",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535575/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535575/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26535577",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535577/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535577/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26536222",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536222/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536222/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26536228",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536228/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536228/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26536297",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536297/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536297/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26536908",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536908/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536908/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537079",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537079/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537079/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537170",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537170/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537170/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537238",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537238/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537238/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537370",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537370/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537370/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537407",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537407/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537407/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537420",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537420/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537420/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537450",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537450/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537450/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537466",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537466/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537466/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537467",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537467/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537467/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537476",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537476/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537476/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537480",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537480/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537480/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537487",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537487/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537487/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537505",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537505/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537505/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537507",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537507/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537507/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537514",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537514/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537514/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26537519",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537519/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537519/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn26642471",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642471/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642471/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642472",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642472/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642472/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642481",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642481/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642481/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642482",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642482/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642482/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642484",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642484/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642484/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642485",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642485/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642485/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642486",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642486/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642486/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642487",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642487/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642487/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642488",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642488/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642488/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642489",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642489/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642489/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642490",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642490/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642490/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642491",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642491/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642491/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642494",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642494/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642494/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642495",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642495/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642495/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642496",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642496/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642496/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642497",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642497/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642497/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642500",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642500/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642500/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642501",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642501/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642501/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642502",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642502/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642502/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642503",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642503/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642503/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642504",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642504/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642504/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642506",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642506/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642506/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642507",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642507/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642507/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642508",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642508/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642508/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642509",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642509/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642509/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642510",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642510/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642510/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642511",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642511/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642511/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642512",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642512/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642512/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642513",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642513/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642513/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642514",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642514/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642514/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26642515",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642515/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642515/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26643894",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn26643896",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/thumbnail.png"
-  },
-  {
-    "synid": "syn26644414",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644416",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644421",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644422",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644423",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644426",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644427",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644428",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644429",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644430",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644431",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644432",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644433",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644434",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644435",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644436",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644437",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644438",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644439",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644440",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644441",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644442",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644443",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644444",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644445",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644446",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644447",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644448",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644449",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644450",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644451",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644452",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644453",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644454",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644455",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644456",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644457",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644458",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644459",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644460",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644461",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644462",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644463",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644464",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644465",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644466",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644467",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644468",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644469",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644470",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644471",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644472",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644473",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644474",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644475",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644476",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644477",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644478",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644479",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644480",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644481",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644482",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644483",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644484",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644485",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644486",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644487",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644488",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644489",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644490",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644491",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644492",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644493",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644494",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644495",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644496",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644497",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644498",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644499",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644500",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644501",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644502",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644503",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644504",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644505",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644506",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644507",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644508",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644509",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644510",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644511",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644512",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644513",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644514",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644515",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644516",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644517",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644518",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644519",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644520",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644521",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644522",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644523",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644524",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644525",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644526",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644527",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644528",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644529",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644530",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644531",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644532",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644533",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644534",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644535",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644536",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644537",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644538",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644539",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644540",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644541",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644542",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644543",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644544",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644545",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644546",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644547",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644548",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644549",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644550",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644551",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644552",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644553",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644554",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644555",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644556",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644557",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644558",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644559",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644560",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644561",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644562",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644563",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644564",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644565",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644566",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644567",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644568",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644569",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644570",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644571",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644572",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644573",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644574",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644575",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644576",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644577",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644578",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644579",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644580",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644581",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644582",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644583",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644584",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644585",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644586",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644587",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644588",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644589",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644590",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644591",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644592",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644593",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644594",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644595",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644596",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644597",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644598",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644599",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644600",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644601",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644602",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644603",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644604",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644605",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644606",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644607",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644608",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644609",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644610",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644611",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644612",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644613",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644614",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644615",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644616",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644617",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644618",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644619",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644620",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644621",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644622",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644625",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644626",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644627",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644628",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644629",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644630",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644631",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644632",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644633",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644634",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644635",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644636",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644637",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644638",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644639",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644640",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644641",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644642",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644643",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644644",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644645",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644646",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644647",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644648",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644649",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644650",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/thumbnail.png"
-  },
-  {
-    "synid": "syn26644651",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644652",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644653",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644654",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644655",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644656",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644657",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644658",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644659",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644660",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644661",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644662",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644663",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644664",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644665",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644666",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644667",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644668",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644669",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644670",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644671",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644672",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644673",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644674",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644675",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644676",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644677",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644678",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644679",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644680",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644681",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644682",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644683",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644684",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644685",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644686",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644687",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644688",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644689",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644690",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644691",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644692",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644693",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644694",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644695",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644696",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644697",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644698",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644699",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644700",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644701",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644702",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644703",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644704",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644705",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644706",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644707",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644708",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644709",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644710",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644711",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644712",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644713",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644714",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644715",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644716",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644717",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644718",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644719",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644720",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644721",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644722",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644723",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644724",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644725",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644726",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644727",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644728",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644729",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644730",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644731",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644732",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644733",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644734",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644735",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644736",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644737",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644738",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644739",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644740",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644741",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644742",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644743",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644744",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644745",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644746",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644747",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644748",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644749",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26644750",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/high_franklin/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/high_franklin/thumbnail.png"
-  },
-  {
-    "synid": "syn26937643",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937644",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937645",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937646",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937647",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937648",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937649",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937650",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937651",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937652",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937653",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937654",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937655",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937656",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937657",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937658",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937659",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937660",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937661",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937662",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937663",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937664",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937665",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937666",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937667",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937668",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937669",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937670",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937671",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937672",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937673",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937674",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937675",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937676",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937677",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937678",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937679",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937680",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937681",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937696",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937697",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937730",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937748",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937756",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937757",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937758",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937759",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937760",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937761",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937762",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937763",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937764",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937765",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937766",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937767",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937768",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937769",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937770",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937771",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937772",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937773",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937774",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937775",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937776",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937777",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937778",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937779",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937780",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937781",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937782",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937783",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937784",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937785",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937786",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937787",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937788",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937789",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937790",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937791",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937792",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937793",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937802",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937803",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937804",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937836",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937859",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937860",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937861",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937862",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937863",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937864",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937865",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937866",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937867",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937868",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937869",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937870",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937871",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937872",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937873",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937874",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937875",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937876",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937877",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937878",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937879",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937880",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937881",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937882",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937883",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937884",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937885",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937886",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937887",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937888",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937889",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937890",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937891",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937892",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937893",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937894",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937895",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937896",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937911",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937912",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937950",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937969",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937971",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937972",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937973",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937974",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937975",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937976",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937977",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937978",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937979",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937980",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937981",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937982",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937983",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937984",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937985",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937986",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937987",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937988",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937989",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937990",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937991",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937992",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937994",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937995",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937997",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26937999",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26938001",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn26940250",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/high_mendel/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/magical_cori/thumbnail.png"
-  },
-  {
-    "synid": "syn27021863",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056840",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056841",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056841/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056841/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056842",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056842/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056842/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056843",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056846",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056847",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056849",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056852",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056852/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056852/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056853",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056855",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056857",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056857/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056857/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056858",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056858/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056858/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056859",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056859/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056859/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056860",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056862",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056866",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056866/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056866/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056867",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056867/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056867/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056868",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056893",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056894",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056896",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056908",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056908/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056908/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056912",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056920",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056922",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056922/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056922/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056923",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056927",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056929",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056937",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056937/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056937/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056938",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056938/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056938/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056939",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056945",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056950",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056950/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056950/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056952",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056955",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056960",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056960/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056960/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056961",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056963",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056965",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056965/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056965/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056966",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056966/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056966/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056967",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056970",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056970/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056970/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056971",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056971/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056971/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056972",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056972/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056972/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056973",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056988",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056988/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056988/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056989",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056989/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056989/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056990",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056990/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056990/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056991",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056991/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056991/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056992",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056999",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057000",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057000/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057000/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057001",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057004",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057005",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057008",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057014",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057016",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057020",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057020/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057020/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057021",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057024",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057025",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057042",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057046",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057055",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057059",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057062",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057066",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057075",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057077",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057080",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057080/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057080/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057081",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057092",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057097",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057110",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057112",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057112/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057112/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057113",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057121",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057127",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057127/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057127/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057128",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057128/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057128/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057129",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057137",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057141",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057161",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057164",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057164/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057164/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057165",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057165/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057165/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057166",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057174",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057174/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057174/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057175",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057175/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057175/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057176",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057176/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057176/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057177",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057182",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057184",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057189",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057189/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057189/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057190",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057194",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057206",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057206/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057206/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057207",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057207/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057207/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057208",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057208/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057208/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057209",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057212",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057214",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057217",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057217/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057217/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057218",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057220",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057220/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057220/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057221",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057221/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057221/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057222",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057226",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057228",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057230",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057235",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057235/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057235/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057236",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057240",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057240/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057240/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057241",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057241/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057241/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057242",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057245",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057247",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057247/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057247/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057248",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057248/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057248/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057249",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057256",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057256/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057256/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057257",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057257/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057257/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057258",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057258/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057258/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057259",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057259/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057259/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057260",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057270",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057275",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057275/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057275/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057281",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057296",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057296/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057296/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057304",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057304/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057304/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057306",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057306/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057306/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057311",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057311/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057311/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057317",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057322",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057322/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057322/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057324",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057324/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057324/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057325",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057325/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057325/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057326",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057326/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057326/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057327",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057327/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057327/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057328",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057330",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057331",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057331/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057331/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057332",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057332/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057332/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057333",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057333/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057333/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057334",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057337",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057338",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057340",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057342",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057342/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057342/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057343",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057343/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057343/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057344",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057344/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057344/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057345",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057348",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057348/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057348/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057349",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057349/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057349/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057350",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057350/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057350/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057351",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057351/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057351/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057352",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057352/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057352/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057353",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057353/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057353/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057354",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057354/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057354/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057355",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057355/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057355/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057356",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057356/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057356/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057357",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057362",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057363",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057363/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057363/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057364",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057364/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057364/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057365",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057365/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057365/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057366",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057366/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057366/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057367",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057367/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057367/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057368",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057372",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057372/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057372/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057373",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057373/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057373/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057374",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057374/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057374/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057375",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057375/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057375/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057377",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057377/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057377/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057378",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057378/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057378/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057379",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057379/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057379/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057380",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057382",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057383",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057383/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057383/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057384",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057384/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057384/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057385",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057387",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057388",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057390",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057390/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057390/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057391",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057391/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057391/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057392",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057392/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057392/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057393",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057393/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057393/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057394",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057394/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057394/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057395",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057397",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057397/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057397/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057398",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057398/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057398/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057399",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057399/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057399/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057400",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057400/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057400/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057401",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057401/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057401/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057402",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057402/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057402/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057403",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057405",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057407",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057407/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057407/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057408",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057408/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057408/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057409",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057409/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057409/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057410",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057410/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057410/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057411",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057411/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057411/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057412",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057412/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057412/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057413",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057416",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057416/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057416/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057417",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057417/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057417/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057418",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057418/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057418/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057419",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057419/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057419/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057420",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057420/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057420/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057421",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057421/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057421/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057422",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057422/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057422/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057423",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057423/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057423/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057424",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057424/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057424/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057425",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057425/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057425/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057426",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057426/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057426/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057427",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057427/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057427/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057428",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057428/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057428/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057429",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057431",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057432",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057432/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057432/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057433",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057433/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057433/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057434",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057436",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057436/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057436/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057437",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057437/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057437/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057438",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057438/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057438/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057439",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057439/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057439/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057440",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057440/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057440/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057441",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057443",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057445",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057445/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057445/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057446",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057446/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057446/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057447",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057447/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057447/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057448",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057448/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057448/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057449",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057449/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057449/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057450",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057452",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057452/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057452/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057453",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057453/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057453/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057454",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057454/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057454/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057455",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057455/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057455/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057456",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057456/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057456/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057457",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057457/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057457/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057458",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057460",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057460/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057460/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057461",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057461/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057461/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057462",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057462/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057462/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057463",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057463/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057463/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057464",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057464/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057464/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057465",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057465/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057465/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057466",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057466/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057466/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057467",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057467/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057467/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057468",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057468/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057468/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057469",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057469/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057469/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057470",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057470/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057470/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057471",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057471/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057471/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057472",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057472/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057472/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057473",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057473/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057473/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057474",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057474/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057474/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057475",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057477",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057477/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057477/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057478",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057478/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057478/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057479",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057479/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057479/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057480",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057480/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057480/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057481",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057481/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057481/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057482",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057482/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057482/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057483",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057483/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057483/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057484",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057484/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057484/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057485",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057485/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057485/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057486",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057486/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057486/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057487",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057487/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057487/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057488",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057488/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057488/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057489",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057489/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057489/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057490",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057490/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057490/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057491",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057491/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057491/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057492",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057492/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057492/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057493",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057493/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057493/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057494",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057494/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057494/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057497",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057497/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057497/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057498",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057498/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057498/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057499",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057499/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057499/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057500",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057500/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057500/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057501",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057501/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057501/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057502",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057504",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057505",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057505/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057505/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057506",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057506/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057506/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057507",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057507/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057507/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057508",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057508/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057508/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057509",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057509/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057509/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057510",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057510/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057510/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057511",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057511/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057511/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057512",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057512/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057512/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057513",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057513/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057513/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057514",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057514/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057514/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057515",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057515/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057515/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057516",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057516/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057516/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057521",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057521/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057521/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057522",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057522/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057522/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057523",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057523/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057523/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057524",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057526",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057527",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057527/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057527/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057528",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057528/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057528/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057529",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057529/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057529/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057530",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057530/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057530/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057531",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057533",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057533/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057533/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057534",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057534/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057534/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057535",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057535/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057535/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057536",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057536/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057536/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057537",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057537/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057537/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057538",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057538/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057538/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057539",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057539/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057539/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057540",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057540/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057540/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057542",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057542/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057542/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057543",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057543/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057543/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057544",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057544/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057544/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057545",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057545/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057545/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057546",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057548",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057549",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057549/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057549/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057550",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057550/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057550/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057551",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057551/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057551/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057552",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057552/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057552/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057553",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057553/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057553/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057554",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057554/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057554/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057555",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057555/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057555/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057556",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057556/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057556/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057557",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057557/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057557/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057560",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057560/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057560/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057562",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057562/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057562/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057563",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057565",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057566",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057566/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057566/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057567",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057567/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057567/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057568",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057568/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057568/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057569",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057569/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057569/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057570",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057570/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057570/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057572",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057572/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057572/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057573",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057573/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057573/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057574",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057574/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057574/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057575",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057575/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057575/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057576",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057576/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057576/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057577",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057579",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057580",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057582",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057584",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057584/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057584/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057585",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057587",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057587/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057587/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057588",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057588/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057588/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057589",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057589/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057589/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057590",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057593",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057593/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057593/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057594",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057594/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057594/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057595",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057595/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057595/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057596",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057596/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057596/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057597",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057597/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057597/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057598",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057598/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057598/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057599",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057599/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057599/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057600",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057602",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057602/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057602/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057603",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057603/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057603/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057604",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057604/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057604/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057605",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057605/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057605/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057606",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057606/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057606/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057607",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057607/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057607/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057608",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057608/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057608/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057609",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057609/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057609/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057610",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057610/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057610/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057611",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057611/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057611/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057612",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057612/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057612/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057613",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057613/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057613/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057614",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057614/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057614/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057615",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057615/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057615/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057628",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393120",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393120/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393120/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393123",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393123/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393123/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393124",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393124/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393124/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393131",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393131/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393131/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393133",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393138",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393138/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393138/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393156",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393156/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393156/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393178",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393191",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393199",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393199/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393199/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393203",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393203/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393203/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393207",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393207/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393207/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393209",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393209/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393209/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393213",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393213/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393213/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393214",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393214/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393214/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393216",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393216/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393216/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393217",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393217/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393217/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393221",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393221/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393221/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393223",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393234",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393239",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393239/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393239/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393242",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393242/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393242/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393243",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393243/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393243/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393250",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393250/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393250/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393254",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393254/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393254/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393256",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393258",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393258/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393258/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393262",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393262/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393262/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393263",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393263/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393263/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393268",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393268/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393268/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393272",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393272/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393272/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393274",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393274/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393274/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393276",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393276/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393276/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393277",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393277/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393277/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393280",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393280/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393280/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393281",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393284",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393284/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393284/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393285",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393285/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393285/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393290",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393290/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393296",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393296/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393296/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393298",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393298/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393298/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393300",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393300/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393300/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393301",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393301/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393301/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393303",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393303/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393303/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393304",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393306",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393760",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393760/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393760/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393761",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393761/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393761/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393764",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393764/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393764/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393767",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393769",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393769/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393769/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393772",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393773",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393773/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393773/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393775",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393775/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393775/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393776",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393776/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393776/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393778",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393778/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393778/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393779",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393779/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393779/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393780",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393780/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393780/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393781",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393781/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393781/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393782",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393782/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393782/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393784",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393784/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393784/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393785",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393785/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393785/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393787",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393787/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393787/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393789",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393789/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393789/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393790",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393792",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393792/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393792/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393793",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393793/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393793/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393794",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393794/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393794/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393795",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393795/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393795/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393796",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393796/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393796/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393797",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393797/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393797/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27393799",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/v1/minerva/index.html",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/sad_poitras_3/thumbnail.jpg"
-  },
-  {
-    "synid": "syn28564179",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564180",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564188",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564193",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564197",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564201",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564202",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564204",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564205",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564208",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564212",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564213",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564216",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564220",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564221",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564226",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564227",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564230",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564232",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564233",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564234",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564239",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564242",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564251",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564253",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564269",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564270",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564275",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564279",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564284",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564301",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564306",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564330",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564350",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564376",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564381",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564393",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564441",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564494",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564516",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564520",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564528",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564538",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564542",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564549",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564552",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564554",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564566",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564569",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564581",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564584",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564585",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564602",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564608",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564611",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564614",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564616",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564621",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564625",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564630",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564644",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564645",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564649",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564658",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564664",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564666",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564671",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564675",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564677",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564693",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564694",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564702",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564703",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564705",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/index.html"
-  },
-  {
-    "synid": "syn28564712",
-    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/index.html"
-  }
+    {
+        "synid":"syn24829425",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829425/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829425/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829426",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829426/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829426/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829428",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829428/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829428/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829429",a
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829429/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829429/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829430",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829430/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829430/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829431",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829431/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829431/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829432",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829432/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829432/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829433",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829433/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829433/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829434",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829434/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829434/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829435",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829435/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829435/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829436",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829436/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829436/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829437",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829437/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829437/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829438",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829438/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829438/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829439",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829439/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829439/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829440",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829440/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829440/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829441",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829441/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829441/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829442",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829442/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829442/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829443",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829443/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829443/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829444",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829444/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829444/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829445",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829445/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829445/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829446",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829446/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829446/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829447",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829447/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829447/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829448",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829448/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829448/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829449",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829449/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829449/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829450",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829450/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829450/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829451",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829451/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829451/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829452",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829452/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829452/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829453",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829453/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829453/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829454",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829454/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829454/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829455",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829455/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829455/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829456",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829456/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829456/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829457",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829457/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829457/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829458",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829458/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829458/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829459",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829459/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829459/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829460",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829460/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829460/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829461",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829461/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829461/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829462",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829462/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829462/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829463",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829463/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829463/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829464",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829464/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829464/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829465",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829465/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829465/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829466",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829466/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829466/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829467",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829467/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829467/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829468",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829468/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829468/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829469",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829469/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829469/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829470",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829470/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829470/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829471",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829471/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829471/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829472",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829472/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829472/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829473",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829473/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829473/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829474",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829474/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829474/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829475",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829475/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829475/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829476",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829476/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829476/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829477",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829477/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829477/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829478",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829478/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829478/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829479",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829479/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829479/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829480",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829480/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829480/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829481",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829481/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829481/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829482",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829482/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829482/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829483",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829483/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829483/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829484",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829484/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829484/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24829485",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829485/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829485/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24986807",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24986807/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24986807/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992967",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992967/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992968",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992968/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992969",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992969/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992970",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992970/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992971",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992971/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992973",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992973/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992974",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992974/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992975",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992975/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992977",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992977/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992978",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992978/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992979",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992979/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992980",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992980/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992981",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992981/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992982",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992982/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992983",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992983/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992984",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992984/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992985",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992985/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992986",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992986/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992987",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992987/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992988",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992988/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992989",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992989/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992990",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992990/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992991",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992991/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992992",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992992/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992993",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992993/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992994",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992994/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992996",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992996/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992997",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992997/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992998",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992998/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24992999",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992999/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993000",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993000/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993001",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993001/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993002",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993002/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993003",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993003/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993005",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993005/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993007",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993007/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993008",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993008/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993009",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993009/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993010",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993010/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993011",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993011/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993012",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993012/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993013",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993013/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993014",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993014/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993016",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993016/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993017",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993017/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993018",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993018/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993019",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993019/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993020",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993020/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993021",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993021/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993022",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993022/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993023",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993023/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993024",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993024/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993025",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993025/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993026",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993026/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993027",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993027/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993029",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993029/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993031",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993031/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993032",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993032/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993033",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993033/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993034",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993034/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993035",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993035/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993036",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993036/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993037",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993037/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993039",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993039/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993040",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993040/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993046",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993046/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993048",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993048/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993050",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993050/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993057",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993057/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993063",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993063/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn24993069",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993069/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25054776",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25054776/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25054776/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25055566",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055566/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055566/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25055737",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055737/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055737/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25055797",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055797/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055797/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25056191",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056191/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056191/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25056480",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056480/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056480/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25056808",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056808/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056808/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25057095",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057095/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057095/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25057262",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057262/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057262/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25058438",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25058438/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25058438/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25059248",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059248/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059248/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25059795",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059795/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059795/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25059811",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059811/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059811/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25060020",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060020/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060020/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25060047",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060047/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060047/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25060077",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060077/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060077/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25068083",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25068083/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25068083/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25070310",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070310/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070310/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25070644",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070644/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070644/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25071129",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071129/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071129/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25071714",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071714/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071714/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25071769",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071769/elated_poisson/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071769/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25071777",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071777/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071777/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25072720",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25072720/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25072779",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25072779/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25073076",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25073076/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25073076/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25074523",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074523/nasty_ekeblad/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074523/nasty_ekeblad/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25074974",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25074976",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25074996",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075278",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075282",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075311",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075365",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075398",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075400",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075411",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075415",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075429",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075431",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075475",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075480",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075484",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075487",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/big_panini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/nasty_ekeblad/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075505",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075516",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075529",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075561",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075587",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075636",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075636/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075664",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075664/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075664/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075713",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075782",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075869",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075875",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075901",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075912",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075926",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25075948",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076001",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076004",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076014",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076021",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076038",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076062",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076096",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076108",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076147",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076156",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076184",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076268",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076369",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076441",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076572",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076608",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25076711",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077585",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077585/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077585/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077641",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077641/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077641/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077680",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077680/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077680/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077727",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077727/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077727/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077777",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077777/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077839",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077839/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077877",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077877/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077877/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077900",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077900/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077900/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077940",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077940/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077940/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25077960",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077960/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077960/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25078332",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25078332/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25078512",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25078512/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25079158",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25079158/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25079158/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25080543",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080543/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080543/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25080595",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080595/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25080720",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080720/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080720/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25081236",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081236/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25081468",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081468/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081468/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25082605",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25082605/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25083176",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083176/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083176/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25083552",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25114909",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25115882",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25117091",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25547790",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547790/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547790/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547793",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547794",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547796",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547797",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547798",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547798/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547798/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547800",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547801",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547802",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547803",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547803/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547803/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547805",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547805/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547805/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547806",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547806/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547806/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547808",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547808/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547809",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547809/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547811",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547812",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547812/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547812/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547814",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547815",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547815/big_panini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25547816",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547816/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547817",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547817/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547817/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547818",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/naughty_rubens/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547819",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547819/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547819/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547820",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547820/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547821",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547822",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547822/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547822/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547823",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547824",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547825",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547825/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547825/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547826",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25547827",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25547828",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547828/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25665299",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665299/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665299/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25665424",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665424/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665424/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25665553",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665553/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665553/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25665640",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665640/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665640/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25665766",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665766/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665766/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25665870",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665870/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665870/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666058",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666058/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666058/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666170",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666170/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666170/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666276",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666276/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666276/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666409",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666409/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666409/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666476",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666476/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666476/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666622",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666622/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666622/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666713",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666713/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666713/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666775",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666775/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666775/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25666862",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666862/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666862/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701019",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701019/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701020",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701020/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701023",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701023/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701025",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701025/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701026",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701026/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701030",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701030/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701033",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701033/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701036",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701036/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701038",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701038/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701040",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701040/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701043",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701043/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701044",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701044/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701046",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701046/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701048",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701048/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701050",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701050/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701052",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701052/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701055",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701055/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701056",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701056/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701058",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701058/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701060",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701060/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701064",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701064/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701066",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701066/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701069",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701069/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701071",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701071/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701073",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701073/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701077",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701077/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701078",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701078/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701081",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701081/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701083",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701083/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701085",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701085/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701087",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701087/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701089",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701089/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701092",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701092/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701094",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701094/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701097",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701097/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701100",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701100/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701102",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701102/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701104",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701104/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701106",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701106/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701108",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701108/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701110",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701110/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701112",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701112/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701114",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701114/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701116",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701116/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701118",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701118/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701120",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701120/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701122",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701122/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701126",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701126/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701128",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701128/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701131",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701131/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701133",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701133/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701136",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701136/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701140",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701140/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701142",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701142/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701145",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701145/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701146",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701146/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701149",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701149/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701151",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701151/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701154",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701154/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701156",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701156/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701159",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701159/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701162",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701162/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701164",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701164/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701166",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701166/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701168",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701168/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701170",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701170/stoic_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701172",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701172/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701174",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701174/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701176",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701176/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701179",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701179/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701180",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701180/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701182",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701182/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701184",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701184/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701188",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701188/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701190",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701190/kickass_mirzakhani/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701193",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701193/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701195",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701195/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25701198",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701198/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25757216",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25871033",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871034",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871035",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871036",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871036/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871037",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871038",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871039",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871040",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871042",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871043",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871046",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871048",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871048/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871048/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871049",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871049/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871052",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871052/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871056",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871061",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871061/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871061/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871063",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871063/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871063/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871069",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871069/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871069/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871070",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871071",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871071/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871071/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871072",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871073",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/naughty_rubens/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/big_panini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25871074",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871074/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871074/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871075",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871075/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871075/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871076",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871076/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871076/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871078",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871078/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871078/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871079",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871079/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871079/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871080",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871081",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871081/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871081/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871082",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871083",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871083/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871083/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871084",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/big_panini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25871085",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871086",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871087",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871087/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871089",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871090",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871091",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871092",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871093",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871094",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871094/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871094/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871096",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871097",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871098",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871099",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871100",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871101",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871114",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871117",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871118",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/big_panini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25871119",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871121",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871122",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871123",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871123/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871123/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871124",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871125",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871126",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871126/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871126/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871129",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871130",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871132",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871132/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871132/loving_swartz_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25871133",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871139",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871140",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871143",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871147",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25871148",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn25874083",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874083/confident_shaw_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874083/confident_shaw_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25874084",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874084/confident_shaw_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874084/confident_shaw_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25874088",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874088/confident_shaw_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874088/confident_shaw_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25874089",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874089/confident_shaw_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874089/confident_shaw_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25874099",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874099/confident_shaw_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874099/confident_shaw_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25874101",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874101/confident_shaw_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874101/confident_shaw_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882267",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882268",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882269",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882270",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882273",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882275",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882276",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882277",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882282",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882289",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882315",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882315/confident_shaw_3/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882315/confident_shaw_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn25882965",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882965/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882965/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25882990",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882990/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882990/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883086",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883086/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883086/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883126",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883126/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883126/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883141",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883141/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883141/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883160",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883160/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883160/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883246",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883246/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883246/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883274",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883295",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883295/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883295/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883318",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883318/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883318/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883326",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883326/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883326/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883365",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883365/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883365/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883382",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883382/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883382/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883391",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883391/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883391/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883395",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883405",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883416",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883416/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883416/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25883433",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883433/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883433/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn25884288",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25884288/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25884288/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344274",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344274/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344274/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344275",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344275/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344275/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344276",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344276/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344276/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344277",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344277/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344277/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344278",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344278/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344278/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344279",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344279/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344279/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344280",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344280/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344280/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344281",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344281/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344281/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344282",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344282/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344282/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344283",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344283/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344283/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344284",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344284/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344284/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344285",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344285/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344285/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344286",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344286/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344286/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344287",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344287/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344287/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344288",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344288/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344288/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344289",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344289/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344289/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344290",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344290/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344290/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344291",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344291/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344291/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344292",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344292/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344292/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344293",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344293/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344293/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344294",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344294/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344294/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344295",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344295/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344295/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344296",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344296/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344296/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344297",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344297/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344297/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344298",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344298/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344298/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344299",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344299/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344299/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344300",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344300/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344300/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344301",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344301/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344301/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344302",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344302/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344302/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344303",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344303/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344303/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344304",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344304/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344304/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344305",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344305/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344305/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344306",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344306/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344306/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344307",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344307/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344307/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344308",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344308/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344308/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344309",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344309/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344309/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344310",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344310/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344310/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344311",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344311/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344311/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344312",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344312/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344312/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344313",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344313/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344313/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344314",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344314/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344314/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344315",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344315/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344315/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344316",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344316/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344316/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344317",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344317/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344317/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344318",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344318/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344318/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344319",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344319/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344319/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344320",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344320/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344320/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344321",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344321/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344321/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344322",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344322/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344322/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344323",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344323/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344323/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344324",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344324/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344324/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344325",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344325/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344325/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344326",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344326/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344326/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344327",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344327/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344327/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344328",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344328/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344328/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344329",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344329/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344329/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344330",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344330/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344330/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26344331",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344331/hungry_montalcini/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344331/hungry_montalcini/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26445552",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445552/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445552/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26445553",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445553/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445553/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26445554",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445554/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445554/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26445555",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445555/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445555/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26445556",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445556/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445556/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26445557",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445557/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445557/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26445558",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445558/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445558/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26445559",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445559/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445559/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452482",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452482/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452482/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452504",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452504/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452504/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452505",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452505/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452505/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452508",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452508/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452508/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452509",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452509/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452509/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452510",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452510/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452510/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452511",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452511/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452511/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452512",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452512/golden_leavitt/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452513",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452513/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452513/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452523",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452523/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452523/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452527",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452527/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452527/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26452529",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26466814",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466814/golden_leavitt/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26466819",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466819/golden_leavitt/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26466822",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466822/golden_leavitt/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486747",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486749",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486751",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486754",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486755",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486757",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486759",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486771",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486773",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486775",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486777",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486779",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486781",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486783",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486785",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486787",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486789",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486791",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26486793",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26529074",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529074/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529074/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26529076",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26535446",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535446/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535446/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535455",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535455/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535455/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535456",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535456/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535456/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535472",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535472/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535472/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535474",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535474/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535474/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535475",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535475/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535475/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535479",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535479/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535479/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535480",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535480/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535480/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535481",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535481/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535481/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535483",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535483/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535483/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535495",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535495/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535495/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535498",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535498/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535498/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535499",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535499/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535499/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535516",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535516/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535516/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535526",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535526/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535526/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535533",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535533/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535533/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535552",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535552/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535552/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535554",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535554/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535554/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535557",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535557/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535557/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535559",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535559/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535559/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535567",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535567/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535567/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535569",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535569/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535569/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535570",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535570/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535570/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535573",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535573/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535573/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535575",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535575/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535575/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26535577",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535577/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535577/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26536222",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536222/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536222/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26536228",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536228/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536228/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26536297",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536297/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536297/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26536908",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536908/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536908/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537079",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537079/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537079/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537170",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537170/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537170/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537238",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537238/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537238/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537370",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537370/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537370/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537407",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537407/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537407/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537420",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537420/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537420/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537450",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537450/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537450/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537466",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537466/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537466/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537467",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537467/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537467/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537476",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537476/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537476/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537480",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537480/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537480/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537487",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537487/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537487/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537505",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537505/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537505/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537507",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537507/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537507/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537514",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537514/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537514/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26537519",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537519/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537519/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn26642471",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642471/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642471/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642472",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642472/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642472/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642481",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642481/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642481/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642482",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642482/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642482/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642484",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642484/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642484/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642485",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642485/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642485/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642486",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642486/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642486/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642487",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642487/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642487/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642488",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642488/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642488/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642489",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642489/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642489/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642490",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642490/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642490/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642491",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642491/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642491/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642494",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642494/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642494/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642495",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642495/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642495/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642496",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642496/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642496/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642497",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642497/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642497/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642500",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642500/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642500/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642501",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642501/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642501/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642502",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642502/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642502/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642503",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642503/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642503/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642504",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642504/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642504/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642506",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642506/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642506/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642507",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642507/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642507/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642508",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642508/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642508/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642509",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642509/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642509/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642510",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642510/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642510/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642511",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642511/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642511/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642512",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642512/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642512/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642513",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642513/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642513/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642514",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642514/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642514/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26642515",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642515/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642515/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26643894",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26643896",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644414",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644416",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644421",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644422",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644423",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644426",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644427",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644428",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644429",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644430",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644431",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644432",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644433",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644434",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644435",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644436",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644437",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644438",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644439",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644440",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644441",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644442",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644443",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644444",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644445",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644446",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644447",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644448",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644449",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644450",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644451",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644452",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644453",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644454",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644455",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644456",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644457",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644458",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644459",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644460",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644461",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644462",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644463",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644464",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644465",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644466",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644467",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644468",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644469",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644470",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644471",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644472",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644473",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644474",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644475",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644476",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644477",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644478",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644479",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644480",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644481",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644482",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644483",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644484",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644485",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644486",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644487",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644488",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644489",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644490",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644491",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644492",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644493",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644494",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644495",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644496",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644497",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644498",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644499",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644500",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644501",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644502",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644503",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644504",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644505",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644506",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644507",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644508",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644509",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644510",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644511",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644512",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644513",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644514",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644515",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644516",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644517",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644518",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644519",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644520",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644521",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644522",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644523",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644524",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644525",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644526",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644527",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644528",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644529",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644530",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644531",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644532",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644533",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644534",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644535",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644536",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644537",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644538",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644539",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644540",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644541",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644542",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644543",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644544",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644545",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644546",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644547",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644548",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644549",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644550",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644551",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644552",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644553",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644554",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644555",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644556",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644557",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644558",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644559",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644560",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644561",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644562",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644563",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644564",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644565",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644566",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644567",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644568",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644569",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644570",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644571",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644572",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644573",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644574",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644575",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644576",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644577",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644578",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644579",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644580",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644581",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644582",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644583",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644584",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644585",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644586",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644587",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644588",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644589",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644590",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644591",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644592",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644593",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644594",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644595",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644596",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644597",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644598",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644599",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644600",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644601",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644602",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644603",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644604",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644605",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644606",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644607",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644608",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644609",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644610",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644611",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644612",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644613",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644614",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644615",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644616",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644617",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644618",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644619",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644620",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644621",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644622",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644625",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644626",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644627",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644628",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644629",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644630",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644631",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644632",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644633",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644634",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644635",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644636",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644637",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644638",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644639",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644640",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644641",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644642",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644643",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644644",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644645",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644646",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644647",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644648",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644649",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644650",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644651",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644652",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644653",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644654",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644655",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644656",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644657",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644658",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644659",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644660",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644661",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644662",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644663",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644664",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644665",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644666",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644667",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644668",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644669",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644670",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644671",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644672",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644673",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644674",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644675",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644676",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644677",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644678",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644679",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644680",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644681",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644682",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644683",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644684",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644685",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644686",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644687",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644688",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644689",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644690",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644691",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644692",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644693",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644694",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644695",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644696",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644697",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644698",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644699",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644700",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644701",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644702",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644703",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644704",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644705",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644706",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644707",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644708",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644709",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644710",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644711",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644712",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644713",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644714",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644715",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644716",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644717",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644718",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644719",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644720",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644721",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644722",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644723",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644724",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644725",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644726",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644727",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644728",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644729",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644730",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644731",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644732",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644733",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644734",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644735",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644736",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644737",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644738",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644739",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644740",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644741",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644742",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644743",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644744",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644745",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644746",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644747",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644748",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644749",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26644750",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/high_franklin/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/high_franklin/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937643",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937644",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937645",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937646",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937647",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937648",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937649",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937650",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937651",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937652",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937653",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937654",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937655",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937656",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937657",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937658",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937659",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937660",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937661",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937662",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937663",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937664",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937665",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937666",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937667",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937668",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937669",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937670",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937671",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937672",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937673",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937674",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937675",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937676",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937677",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937678",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937679",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937680",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937681",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937696",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937697",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937730",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937748",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937756",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937757",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937758",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937759",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937760",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937761",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937762",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937763",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937764",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937765",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937766",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937767",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937768",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937769",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937770",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937771",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937772",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937773",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937774",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937775",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937776",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937777",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937778",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937779",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937780",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937781",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937782",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937783",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937784",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937785",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937786",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937787",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937788",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937789",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937790",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937791",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937792",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937793",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937802",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937803",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937804",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937836",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937859",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937860",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937861",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937862",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937863",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937864",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937865",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937866",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937867",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937868",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937869",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937870",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937871",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937872",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937873",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937874",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937875",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937876",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937877",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937878",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937879",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937880",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937881",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937882",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937883",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937884",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937885",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937886",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937887",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937888",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937889",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937890",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937891",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937892",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937893",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937894",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937895",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937896",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937911",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937912",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937950",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937969",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937971",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937972",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937973",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937974",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937975",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937976",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937977",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937978",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937979",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937980",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937981",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937982",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937983",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937984",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937985",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937986",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937987",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937988",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937989",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937990",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937991",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937992",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937994",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937995",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937997",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26937999",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26938001",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn26940250",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/high_mendel/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/magical_cori/thumbnail.png"
+    }
+
+    {
+        "synid":"syn27021863",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056840",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056841",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056841/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056841/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056842",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056842/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056842/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056843",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056846",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056847",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056849",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056852",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056852/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056852/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056853",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056855",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056857",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056857/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056857/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056858",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056858/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056858/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056859",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056859/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056859/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056860",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056862",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056866",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056866/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056866/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056867",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056867/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056867/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056868",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056893",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056894",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056896",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056908",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056908/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056908/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056912",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056920",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056922",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056922/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056922/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056923",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056927",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056929",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056937",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056937/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056937/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056938",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056938/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056938/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056939",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056945",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056950",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056950/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056950/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056952",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056955",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056960",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056960/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056960/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056961",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056963",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056965",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056965/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056965/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056966",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056966/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056966/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056967",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056970",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056970/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056970/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056971",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056971/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056971/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056972",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056972/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056972/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056973",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056988",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056988/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056988/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056989",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056989/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056989/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056990",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056990/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056990/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056991",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056991/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056991/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056992",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27056999",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057000",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057000/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057000/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057001",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057004",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057005",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057008",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057014",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057016",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057020",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057020/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057020/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057021",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057024",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057025",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057042",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057046",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057055",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057059",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057062",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057066",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057075",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057077",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057080",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057080/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057080/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057081",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057092",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057097",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057110",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057112",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057112/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057112/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057113",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057121",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057127",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057127/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057127/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057128",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057128/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057128/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057129",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057137",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057141",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057161",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057164",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057164/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057164/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057165",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057165/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057165/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057166",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057174",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057174/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057174/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057175",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057175/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057175/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057176",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057176/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057176/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057177",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057182",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057184",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057189",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057189/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057189/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057190",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057194",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057206",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057206/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057206/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057207",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057207/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057207/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057208",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057208/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057208/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057209",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057212",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057214",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057217",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057217/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057217/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057218",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057220",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057220/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057220/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057221",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057221/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057221/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057222",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057226",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057228",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057230",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057235",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057235/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057235/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057236",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057240",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057240/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057240/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057241",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057241/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057241/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057242",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057245",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057247",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057247/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057247/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057248",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057248/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057248/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057249",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057256",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057256/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057256/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057257",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057257/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057257/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057258",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057258/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057258/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057259",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057259/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057259/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057260",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057270",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057275",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057275/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057275/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057281",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057296",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057296/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057296/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057304",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057304/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057304/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057306",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057306/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057306/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057311",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057311/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057311/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057317",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057322",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057322/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057322/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057324",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057324/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057324/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057325",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057325/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057325/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057326",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057326/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057326/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057327",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057327/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057327/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057328",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057330",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057331",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057331/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057331/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057332",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057332/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057332/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057333",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057333/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057333/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057334",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057337",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057338",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057340",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057342",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057342/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057342/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057343",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057343/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057343/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057344",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057344/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057344/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057345",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057348",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057348/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057348/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057349",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057349/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057349/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057350",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057350/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057350/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057351",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057351/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057351/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057352",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057352/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057352/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057353",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057353/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057353/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057354",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057354/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057354/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057355",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057355/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057355/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057356",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057356/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057356/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057357",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057362",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057363",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057363/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057363/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057364",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057364/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057364/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057365",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057365/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057365/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057366",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057366/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057366/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057367",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057367/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057367/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057368",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057372",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057372/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057372/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057373",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057373/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057373/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057374",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057374/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057374/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057375",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057375/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057375/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057377",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057377/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057377/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057378",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057378/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057378/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057379",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057379/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057379/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057380",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057382",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057383",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057383/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057383/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057384",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057384/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057384/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057385",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057387",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057388",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057390",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057390/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057390/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057391",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057391/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057391/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057392",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057392/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057392/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057393",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057393/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057393/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057394",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057394/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057394/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057395",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057397",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057397/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057397/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057398",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057398/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057398/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057399",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057399/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057399/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057400",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057400/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057400/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057401",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057401/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057401/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057402",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057402/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057402/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057403",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057405",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057407",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057407/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057407/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057408",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057408/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057408/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057409",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057409/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057409/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057410",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057410/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057410/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057411",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057411/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057411/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057412",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057412/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057412/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057413",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057416",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057416/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057416/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057417",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057417/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057417/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057418",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057418/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057418/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057419",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057419/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057419/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057420",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057420/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057420/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057421",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057421/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057421/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057422",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057422/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057422/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057423",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057423/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057423/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057424",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057424/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057424/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057425",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057425/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057425/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057426",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057426/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057426/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057427",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057427/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057427/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057428",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057428/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057428/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057429",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057431",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057432",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057432/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057432/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057433",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057433/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057433/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057434",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057436",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057436/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057436/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057437",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057437/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057437/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057438",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057438/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057438/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057439",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057439/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057439/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057440",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057440/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057440/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057441",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057443",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057445",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057445/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057445/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057446",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057446/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057446/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057447",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057447/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057447/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057448",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057448/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057448/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057449",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057449/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057449/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057450",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057452",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057452/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057452/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057453",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057453/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057453/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057454",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057454/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057454/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057455",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057455/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057455/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057456",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057456/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057456/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057457",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057457/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057457/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057458",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057460",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057460/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057460/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057461",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057461/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057461/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057462",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057462/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057462/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057463",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057463/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057463/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057464",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057464/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057464/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057465",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057465/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057465/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057466",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057466/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057466/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057467",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057467/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057467/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057468",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057468/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057468/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057469",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057469/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057469/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057470",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057470/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057470/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057471",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057471/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057471/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057472",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057472/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057472/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057473",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057473/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057473/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057474",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057474/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057474/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057475",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057477",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057477/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057477/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057478",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057478/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057478/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057479",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057479/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057479/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057480",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057480/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057480/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057481",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057481/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057481/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057482",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057482/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057482/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057483",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057483/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057483/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057484",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057484/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057484/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057485",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057485/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057485/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057486",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057486/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057486/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057487",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057487/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057487/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057488",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057488/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057488/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057489",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057489/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057489/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057490",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057490/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057490/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057491",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057491/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057491/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057492",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057492/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057492/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057493",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057493/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057493/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057494",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057494/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057494/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057497",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057497/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057497/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057498",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057498/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057498/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057499",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057499/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057499/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057500",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057500/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057500/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057501",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057501/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057501/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057502",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057504",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057505",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057505/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057505/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057506",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057506/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057506/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057507",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057507/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057507/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057508",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057508/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057508/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057509",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057509/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057509/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057510",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057510/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057510/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057511",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057511/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057511/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057512",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057512/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057512/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057513",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057513/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057513/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057514",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057514/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057514/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057515",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057515/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057515/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057516",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057516/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057516/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057521",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057521/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057521/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057522",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057522/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057522/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057523",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057523/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057523/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057524",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057526",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057527",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057527/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057527/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057528",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057528/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057528/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057529",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057529/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057529/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057530",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057530/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057530/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057531",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057533",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057533/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057533/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057534",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057534/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057534/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057535",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057535/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057535/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057536",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057536/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057536/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057537",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057537/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057537/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057538",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057538/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057538/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057539",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057539/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057539/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057540",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057540/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057540/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057542",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057542/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057542/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057543",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057543/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057543/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057544",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057544/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057544/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057545",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057545/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057545/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057546",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057548",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057549",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057549/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057549/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057550",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057550/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057550/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057551",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057551/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057551/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057552",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057552/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057552/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057553",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057553/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057553/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057554",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057554/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057554/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057555",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057555/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057555/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057556",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057556/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057556/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057557",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057557/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057557/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057560",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057560/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057560/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057562",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057562/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057562/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057563",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057565",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057566",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057566/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057566/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057567",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057567/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057567/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057568",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057568/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057568/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057569",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057569/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057569/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057570",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057570/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057570/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057572",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057572/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057572/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057573",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057573/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057573/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057574",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057574/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057574/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057575",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057575/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057575/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057576",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057576/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057576/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057577",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057579",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057580",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057582",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057584",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057584/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057584/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057585",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057587",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057587/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057587/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057588",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057588/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057588/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057589",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057589/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057589/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057590",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057593",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057593/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057593/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057594",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057594/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057594/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057595",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057595/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057595/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057596",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057596/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057596/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057597",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057597/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057597/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057598",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057598/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057598/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057599",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057599/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057599/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057600",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057602",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057602/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057602/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057603",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057603/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057603/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057604",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057604/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057604/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057605",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057605/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057605/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057606",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057606/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057606/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057607",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057607/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057607/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057608",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057608/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057608/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057609",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057609/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057609/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057610",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057610/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057610/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057611",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057611/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057611/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057612",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057612/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057612/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057613",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057613/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057613/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057614",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057614/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057614/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057615",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057615/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057615/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27057628",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393120",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393120/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393120/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393123",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393123/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393123/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393124",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393124/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393124/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393131",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393131/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393131/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393133",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393138",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393138/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393138/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393156",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393156/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393156/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393178",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393191",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393199",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393199/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393199/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393203",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393203/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393203/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393207",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393207/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393207/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393209",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393209/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393209/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393213",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393213/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393213/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393214",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393214/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393214/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393216",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393216/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393216/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393217",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393217/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393217/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393221",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393221/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393221/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393223",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393234",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393239",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393239/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393239/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393242",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393242/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393242/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393243",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393243/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393243/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393250",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393250/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393250/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393254",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393254/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393254/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393256",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393258",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393258/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393258/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393262",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393262/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393262/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393263",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393263/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393263/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393268",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393268/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393268/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393272",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393272/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393272/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393274",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393274/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393274/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393276",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393276/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393276/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393277",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393277/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393277/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393280",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393280/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393280/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393281",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393284",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393284/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393284/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393285",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393285/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393285/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393290",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393290/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393296",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393296/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393296/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393298",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393298/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393298/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393300",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393300/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393300/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393301",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393301/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393301/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393303",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393303/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393303/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393304",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393306",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393760",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393760/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393760/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393761",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393761/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393761/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393764",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393764/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393764/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393767",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393769",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393769/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393769/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393772",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393773",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393773/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393773/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393775",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393775/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393775/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393776",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393776/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393776/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393778",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393778/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393778/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393779",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393779/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393779/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393780",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393780/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393780/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393781",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393781/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393781/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393782",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393782/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393782/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393784",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393784/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393784/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393785",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393785/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393785/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393787",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393787/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393787/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393789",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393789/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393789/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393790",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393792",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393792/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393792/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393793",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393793/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393793/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393794",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393794/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393794/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393795",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393795/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393795/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393796",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393796/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393796/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393797",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393797/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393797/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn27393799",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/sad_poitras_3/thumbnail.jpg"
+    }
+
+    {
+        "synid":"syn28564179",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564180",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564188",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564193",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564197",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564201",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564202",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564204",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564205",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564208",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564212",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564213",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564216",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564220",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564221",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564226",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564227",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564230",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564232",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564233",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564234",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564239",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564242",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564251",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564253",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564269",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564270",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564275",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564279",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564284",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564301",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564306",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564330",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564350",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564376",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564381",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564393",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564441",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564494",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564516",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564520",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564528",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564538",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564542",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564549",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564552",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564554",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564566",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564569",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564581",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564584",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564585",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564602",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564608",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564611",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564614",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564616",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564621",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564625",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564630",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564644",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564645",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564649",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564658",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564664",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564666",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564671",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564675",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564677",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564693",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564694",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564702",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564703",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564705",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
+    {
+        "synid":"syn28564712",
+        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/index.html",
+        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+    }
+
 ]

--- a/data/htan-imaging-assets.json
+++ b/data/htan-imaging-assets.json
@@ -1,9692 +1,9716 @@
 [
-    {
-        "synid":"syn24829425",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829425/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829425/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829426",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829426/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829426/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829428",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829428/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829428/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829429",a
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829429/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829429/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829430",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829430/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829430/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829431",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829431/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829431/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829432",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829432/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829432/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829433",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829433/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829433/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829434",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829434/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829434/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829435",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829435/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829435/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829436",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829436/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829436/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829437",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829437/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829437/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829438",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829438/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829438/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829439",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829439/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829439/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829440",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829440/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829440/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829441",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829441/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829441/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829442",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829442/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829442/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829443",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829443/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829443/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829444",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829444/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829444/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829445",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829445/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829445/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829446",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829446/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829446/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829447",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829447/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829447/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829448",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829448/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829448/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829449",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829449/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829449/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829450",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829450/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829450/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829451",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829451/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829451/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829452",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829452/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829452/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829453",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829453/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829453/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829454",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829454/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829454/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829455",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829455/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829455/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829456",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829456/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829456/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829457",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829457/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829457/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829458",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829458/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829458/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829459",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829459/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829459/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829460",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829460/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829460/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829461",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829461/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829461/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829462",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829462/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829462/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829463",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829463/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829463/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829464",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829464/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829464/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829465",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829465/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829465/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829466",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829466/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829466/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829467",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829467/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829467/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829468",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829468/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829468/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829469",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829469/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829469/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829470",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829470/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829470/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829471",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829471/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829471/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829472",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829472/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829472/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829473",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829473/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829473/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829474",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829474/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829474/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829475",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829475/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829475/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829476",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829476/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829476/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829477",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829477/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829477/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829478",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829478/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829478/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829479",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829479/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829479/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829480",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829480/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829480/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829481",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829481/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829481/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829482",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829482/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829482/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829483",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829483/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829483/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829484",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829484/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829484/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24829485",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829485/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829485/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24986807",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24986807/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24986807/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992967",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992967/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992968",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992968/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992969",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992969/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992970",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992970/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992971",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992971/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992973",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992973/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992974",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992974/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992975",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992975/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992977",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992977/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992978",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992978/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992979",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992979/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992980",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992980/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992981",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992981/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992982",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992982/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992983",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992983/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992984",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992984/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992985",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992985/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992986",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992986/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992987",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992987/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992988",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992988/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992989",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992989/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992990",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992990/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992991",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992991/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992992",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992992/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992993",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992993/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992994",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992994/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992996",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992996/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992997",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992997/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992998",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992998/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24992999",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992999/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993000",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993000/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993001",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993001/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993002",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993002/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993003",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993003/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993005",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993005/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993007",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993007/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993008",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993008/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993009",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993009/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993010",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993010/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993011",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993011/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993012",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993012/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993013",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993013/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993014",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993014/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993016",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993016/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993017",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993017/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993018",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993018/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993019",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993019/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993020",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993020/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993021",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993021/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993022",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993022/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993023",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993023/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993024",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993024/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993025",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993025/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993026",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993026/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993027",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993027/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993029",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993029/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993031",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993031/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993032",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993032/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993033",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993033/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993034",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993034/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993035",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993035/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993036",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993036/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993037",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993037/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993039",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993039/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993040",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993040/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993046",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993046/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993048",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993048/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993050",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993050/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993057",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993057/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993063",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993063/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn24993069",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993069/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25054776",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25054776/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25054776/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25055566",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055566/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055566/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25055737",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055737/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055737/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25055797",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055797/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055797/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25056191",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056191/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056191/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25056480",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056480/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056480/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25056808",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056808/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056808/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25057095",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057095/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057095/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25057262",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057262/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057262/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25058438",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25058438/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25058438/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25059248",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059248/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059248/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25059795",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059795/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059795/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25059811",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059811/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059811/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25060020",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060020/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060020/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25060047",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060047/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060047/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25060077",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060077/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060077/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25068083",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25068083/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25068083/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25070310",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070310/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070310/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25070644",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070644/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070644/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25071129",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071129/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071129/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25071714",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071714/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071714/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25071769",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071769/elated_poisson/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071769/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25071777",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071777/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071777/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25072720",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25072720/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25072779",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25072779/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25073076",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25073076/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25073076/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25074523",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074523/nasty_ekeblad/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074523/nasty_ekeblad/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25074974",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25074976",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25074996",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075278",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075282",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075311",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075365",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075398",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075400",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075411",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075415",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075429",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075431",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075475",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075480",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075484",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075487",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/big_panini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/nasty_ekeblad/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075505",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075516",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075529",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075561",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075587",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075636",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075636/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075664",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075664/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075664/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075713",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075782",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075869",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075875",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075901",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075912",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075926",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25075948",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076001",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076004",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076014",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076021",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076038",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076062",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076096",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076108",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076147",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076156",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076184",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076268",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076369",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076441",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076572",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076608",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25076711",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077585",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077585/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077585/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077641",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077641/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077641/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077680",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077680/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077680/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077727",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077727/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077727/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077777",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077777/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077839",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077839/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077877",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077877/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077877/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077900",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077900/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077900/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077940",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077940/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077940/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25077960",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077960/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077960/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25078332",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25078332/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25078512",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25078512/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25079158",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25079158/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25079158/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25080543",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080543/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080543/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25080595",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080595/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25080720",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080720/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080720/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25081236",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081236/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25081468",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081468/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081468/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25082605",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25082605/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25083176",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083176/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083176/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25083552",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25114909",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25115882",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25117091",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25547790",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547790/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547790/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547793",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547794",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547796",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547797",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547798",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547798/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547798/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547800",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547801",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547802",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547803",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547803/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547803/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547805",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547805/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547805/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547806",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547806/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547806/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547808",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547808/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547809",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547809/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547811",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547812",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547812/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547812/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547814",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547815",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547815/big_panini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25547816",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547816/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547817",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547817/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547817/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547818",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/naughty_rubens/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547819",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547819/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547819/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547820",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547820/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547821",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547822",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547822/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547822/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547823",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547824",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547825",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547825/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547825/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547826",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25547827",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25547828",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547828/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25665299",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665299/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665299/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25665424",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665424/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665424/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25665553",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665553/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665553/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25665640",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665640/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665640/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25665766",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665766/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665766/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25665870",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665870/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665870/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666058",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666058/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666058/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666170",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666170/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666170/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666276",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666276/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666276/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666409",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666409/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666409/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666476",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666476/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666476/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666622",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666622/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666622/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666713",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666713/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666713/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666775",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666775/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666775/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25666862",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666862/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666862/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701019",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701019/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701020",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701020/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701023",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701023/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701025",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701025/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701026",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701026/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701030",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701030/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701033",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701033/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701036",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701036/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701038",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701038/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701040",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701040/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701043",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701043/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701044",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701044/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701046",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701046/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701048",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701048/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701050",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701050/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701052",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701052/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701055",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701055/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701056",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701056/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701058",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701058/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701060",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701060/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701064",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701064/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701066",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701066/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701069",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701069/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701071",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701071/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701073",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701073/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701077",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701077/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701078",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701078/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701081",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701081/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701083",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701083/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701085",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701085/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701087",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701087/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701089",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701089/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701092",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701092/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701094",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701094/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701097",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701097/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701100",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701100/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701102",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701102/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701104",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701104/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701106",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701106/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701108",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701108/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701110",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701110/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701112",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701112/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701114",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701114/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701116",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701116/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701118",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701118/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701120",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701120/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701122",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701122/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701126",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701126/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701128",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701128/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701131",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701131/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701133",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701133/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701136",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701136/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701140",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701140/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701142",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701142/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701145",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701145/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701146",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701146/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701149",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701149/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701151",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701151/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701154",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701154/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701156",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701156/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701159",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701159/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701162",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701162/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701164",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701164/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701166",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701166/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701168",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701168/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701170",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701170/stoic_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701172",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701172/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701174",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701174/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701176",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701176/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701179",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701179/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701180",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701180/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701182",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701182/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701184",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701184/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701188",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701188/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701190",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701190/kickass_mirzakhani/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701193",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701193/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701195",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701195/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25701198",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701198/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25757216",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25871033",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871034",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871035",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871036",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871036/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871037",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871038",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871039",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871040",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871042",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871043",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871046",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871048",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871048/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871048/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871049",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871049/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871052",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871052/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871056",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871061",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871061/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871061/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871063",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871063/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871063/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871069",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871069/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871069/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871070",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871071",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871071/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871071/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871072",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871073",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/naughty_rubens/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/big_panini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25871074",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871074/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871074/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871075",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871075/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871075/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871076",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871076/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871076/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871078",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871078/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871078/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871079",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871079/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871079/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871080",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871081",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871081/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871081/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871082",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871083",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871083/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871083/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871084",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/big_panini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25871085",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871086",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871087",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871087/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871089",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871090",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871091",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871092",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871093",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871094",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871094/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871094/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871096",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871097",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871098",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871099",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871100",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871101",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871114",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871117",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871118",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/big_panini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25871119",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871121",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871122",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871123",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871123/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871123/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871124",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871125",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871126",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871126/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871126/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871129",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871130",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871132",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871132/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871132/loving_swartz_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25871133",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871139",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871140",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871143",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871147",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25871148",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn25874083",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874083/confident_shaw_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874083/confident_shaw_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25874084",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874084/confident_shaw_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874084/confident_shaw_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25874088",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874088/confident_shaw_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874088/confident_shaw_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25874089",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874089/confident_shaw_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874089/confident_shaw_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25874099",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874099/confident_shaw_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874099/confident_shaw_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25874101",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874101/confident_shaw_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874101/confident_shaw_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882267",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882268",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882269",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882270",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882273",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882275",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882276",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882277",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882282",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882289",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882315",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882315/confident_shaw_3/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882315/confident_shaw_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn25882965",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882965/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882965/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25882990",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882990/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882990/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883086",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883086/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883086/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883126",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883126/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883126/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883141",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883141/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883141/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883160",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883160/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883160/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883246",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883246/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883246/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883274",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883295",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883295/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883295/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883318",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883318/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883318/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883326",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883326/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883326/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883365",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883365/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883365/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883382",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883382/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883382/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883391",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883391/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883391/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883395",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883405",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883416",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883416/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883416/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25883433",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883433/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883433/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn25884288",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25884288/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn25884288/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344274",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344274/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344274/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344275",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344275/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344275/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344276",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344276/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344276/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344277",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344277/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344277/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344278",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344278/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344278/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344279",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344279/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344279/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344280",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344280/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344280/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344281",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344281/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344281/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344282",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344282/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344282/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344283",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344283/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344283/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344284",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344284/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344284/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344285",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344285/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344285/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344286",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344286/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344286/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344287",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344287/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344287/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344288",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344288/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344288/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344289",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344289/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344289/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344290",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344290/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344290/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344291",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344291/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344291/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344292",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344292/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344292/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344293",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344293/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344293/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344294",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344294/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344294/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344295",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344295/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344295/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344296",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344296/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344296/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344297",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344297/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344297/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344298",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344298/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344298/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344299",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344299/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344299/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344300",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344300/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344300/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344301",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344301/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344301/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344302",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344302/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344302/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344303",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344303/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344303/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344304",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344304/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344304/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344305",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344305/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344305/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344306",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344306/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344306/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344307",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344307/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344307/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344308",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344308/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344308/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344309",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344309/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344309/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344310",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344310/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344310/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344311",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344311/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344311/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344312",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344312/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344312/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344313",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344313/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344313/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344314",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344314/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344314/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344315",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344315/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344315/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344316",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344316/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344316/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344317",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344317/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344317/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344318",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344318/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344318/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344319",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344319/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344319/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344320",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344320/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344320/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344321",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344321/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344321/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344322",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344322/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344322/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344323",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344323/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344323/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344324",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344324/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344324/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344325",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344325/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344325/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344326",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344326/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344326/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344327",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344327/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344327/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344328",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344328/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344328/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344329",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344329/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344329/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344330",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344330/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344330/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26344331",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344331/hungry_montalcini/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344331/hungry_montalcini/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26445552",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445552/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445552/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26445553",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445553/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445553/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26445554",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445554/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445554/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26445555",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445555/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445555/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26445556",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445556/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445556/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26445557",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445557/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445557/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26445558",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445558/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445558/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26445559",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445559/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445559/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452482",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452482/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452482/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452504",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452504/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452504/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452505",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452505/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452505/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452508",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452508/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452508/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452509",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452509/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452509/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452510",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452510/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452510/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452511",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452511/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452511/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452512",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452512/golden_leavitt/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452513",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452513/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452513/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452523",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452523/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452523/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452527",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452527/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452527/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26452529",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26466814",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466814/golden_leavitt/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26466819",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466819/golden_leavitt/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26466822",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466822/golden_leavitt/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486747",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486749",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486751",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486754",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486755",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486757",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486759",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486771",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486773",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486775",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486777",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486779",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486781",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486783",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486785",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486787",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486789",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486791",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26486793",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26529074",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529074/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529074/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26529076",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26535446",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535446/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535446/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535455",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535455/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535455/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535456",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535456/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535456/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535472",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535472/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535472/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535474",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535474/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535474/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535475",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535475/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535475/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535479",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535479/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535479/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535480",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535480/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535480/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535481",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535481/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535481/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535483",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535483/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535483/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535495",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535495/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535495/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535498",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535498/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535498/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535499",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535499/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535499/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535516",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535516/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535516/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535526",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535526/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535526/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535533",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535533/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535533/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535552",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535552/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535552/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535554",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535554/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535554/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535557",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535557/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535557/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535559",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535559/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535559/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535567",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535567/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535567/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535569",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535569/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535569/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535570",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535570/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535570/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535573",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535573/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535573/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535575",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535575/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535575/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26535577",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535577/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535577/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26536222",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536222/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536222/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26536228",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536228/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536228/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26536297",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536297/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536297/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26536908",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536908/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536908/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537079",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537079/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537079/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537170",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537170/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537170/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537238",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537238/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537238/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537370",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537370/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537370/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537407",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537407/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537407/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537420",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537420/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537420/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537450",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537450/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537450/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537466",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537466/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537466/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537467",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537467/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537467/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537476",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537476/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537476/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537480",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537480/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537480/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537487",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537487/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537487/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537505",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537505/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537505/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537507",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537507/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537507/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537514",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537514/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537514/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26537519",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537519/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537519/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn26642471",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642471/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642471/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642472",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642472/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642472/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642481",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642481/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642481/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642482",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642482/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642482/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642484",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642484/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642484/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642485",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642485/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642485/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642486",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642486/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642486/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642487",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642487/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642487/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642488",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642488/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642488/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642489",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642489/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642489/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642490",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642490/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642490/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642491",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642491/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642491/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642494",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642494/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642494/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642495",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642495/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642495/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642496",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642496/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642496/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642497",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642497/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642497/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642500",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642500/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642500/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642501",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642501/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642501/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642502",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642502/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642502/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642503",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642503/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642503/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642504",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642504/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642504/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642506",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642506/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642506/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642507",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642507/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642507/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642508",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642508/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642508/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642509",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642509/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642509/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642510",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642510/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642510/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642511",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642511/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642511/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642512",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642512/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642512/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642513",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642513/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642513/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642514",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642514/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642514/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26642515",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642515/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642515/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26643894",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26643896",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644414",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644416",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644421",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644422",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644423",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644426",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644427",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644428",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644429",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644430",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644431",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644432",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644433",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644434",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644435",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644436",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644437",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644438",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644439",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644440",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644441",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644442",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644443",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644444",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644445",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644446",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644447",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644448",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644449",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644450",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644451",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644452",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644453",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644454",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644455",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644456",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644457",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644458",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644459",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644460",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644461",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644462",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644463",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644464",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644465",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644466",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644467",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644468",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644469",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644470",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644471",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644472",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644473",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644474",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644475",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644476",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644477",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644478",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644479",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644480",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644481",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644482",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644483",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644484",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644485",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644486",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644487",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644488",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644489",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644490",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644491",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644492",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644493",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644494",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644495",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644496",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644497",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644498",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644499",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644500",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644501",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644502",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644503",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644504",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644505",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644506",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644507",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644508",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644509",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644510",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644511",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644512",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644513",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644514",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644515",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644516",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644517",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644518",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644519",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644520",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644521",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644522",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644523",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644524",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644525",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644526",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644527",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644528",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644529",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644530",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644531",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644532",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644533",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644534",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644535",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644536",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644537",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644538",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644539",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644540",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644541",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644542",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644543",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644544",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644545",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644546",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644547",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644548",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644549",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644550",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644551",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644552",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644553",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644554",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644555",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644556",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644557",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644558",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644559",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644560",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644561",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644562",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644563",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644564",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644565",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644566",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644567",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644568",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644569",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644570",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644571",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644572",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644573",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644574",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644575",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644576",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644577",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644578",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644579",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644580",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644581",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644582",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644583",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644584",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644585",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644586",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644587",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644588",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644589",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644590",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644591",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644592",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644593",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644594",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644595",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644596",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644597",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644598",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644599",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644600",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644601",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644602",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644603",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644604",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644605",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644606",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644607",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644608",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644609",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644610",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644611",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644612",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644613",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644614",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644615",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644616",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644617",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644618",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644619",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644620",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644621",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644622",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644625",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644626",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644627",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644628",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644629",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644630",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644631",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644632",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644633",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644634",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644635",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644636",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644637",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644638",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644639",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644640",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644641",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644642",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644643",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644644",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644645",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644646",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644647",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644648",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644649",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644650",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644651",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644652",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644653",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644654",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644655",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644656",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644657",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644658",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644659",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644660",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644661",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644662",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644663",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644664",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644665",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644666",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644667",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644668",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644669",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644670",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644671",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644672",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644673",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644674",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644675",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644676",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644677",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644678",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644679",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644680",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644681",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644682",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644683",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644684",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644685",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644686",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644687",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644688",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644689",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644690",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644691",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644692",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644693",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644694",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644695",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644696",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644697",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644698",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644699",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644700",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644701",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644702",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644703",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644704",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644705",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644706",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644707",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644708",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644709",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644710",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644711",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644712",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644713",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644714",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644715",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644716",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644717",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644718",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644719",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644720",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644721",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644722",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644723",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644724",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644725",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644726",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644727",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644728",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644729",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644730",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644731",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644732",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644733",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644734",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644735",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644736",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644737",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644738",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644739",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644740",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644741",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644742",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644743",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644744",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644745",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644746",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644747",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644748",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644749",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26644750",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/high_franklin/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/high_franklin/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937643",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937644",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937645",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937646",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937647",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937648",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937649",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937650",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937651",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937652",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937653",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937654",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937655",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937656",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937657",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937658",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937659",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937660",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937661",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937662",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937663",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937664",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937665",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937666",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937667",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937668",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937669",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937670",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937671",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937672",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937673",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937674",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937675",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937676",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937677",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937678",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937679",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937680",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937681",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937696",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937697",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937730",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937748",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937756",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937757",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937758",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937759",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937760",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937761",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937762",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937763",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937764",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937765",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937766",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937767",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937768",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937769",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937770",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937771",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937772",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937773",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937774",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937775",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937776",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937777",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937778",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937779",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937780",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937781",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937782",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937783",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937784",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937785",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937786",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937787",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937788",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937789",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937790",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937791",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937792",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937793",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937802",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937803",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937804",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937836",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937859",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937860",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937861",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937862",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937863",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937864",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937865",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937866",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937867",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937868",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937869",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937870",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937871",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937872",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937873",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937874",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937875",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937876",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937877",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937878",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937879",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937880",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937881",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937882",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937883",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937884",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937885",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937886",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937887",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937888",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937889",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937890",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937891",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937892",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937893",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937894",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937895",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937896",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937911",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937912",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937950",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937969",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937971",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937972",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937973",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937974",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937975",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937976",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937977",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937978",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937979",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937980",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937981",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937982",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937983",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937984",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937985",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937986",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937987",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937988",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937989",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937990",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937991",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937992",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937994",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937995",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937997",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26937999",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26938001",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn26940250",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/high_mendel/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/magical_cori/thumbnail.png"
-    }
-
-    {
-        "synid":"syn27021863",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056840",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056841",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056841/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056841/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056842",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056842/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056842/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056843",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056846",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056847",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056849",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056852",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056852/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056852/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056853",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056855",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056857",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056857/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056857/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056858",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056858/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056858/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056859",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056859/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056859/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056860",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056862",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056866",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056866/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056866/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056867",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056867/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056867/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056868",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056893",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056894",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056896",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056908",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056908/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056908/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056912",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056920",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056922",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056922/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056922/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056923",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056927",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056929",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056937",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056937/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056937/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056938",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056938/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056938/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056939",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056945",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056950",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056950/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056950/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056952",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056955",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056960",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056960/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056960/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056961",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056963",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056965",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056965/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056965/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056966",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056966/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056966/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056967",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056970",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056970/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056970/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056971",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056971/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056971/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056972",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056972/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056972/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056973",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056988",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056988/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056988/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056989",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056989/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056989/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056990",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056990/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056990/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056991",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056991/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056991/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056992",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27056999",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057000",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057000/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057000/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057001",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057004",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057005",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057008",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057014",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057016",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057020",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057020/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057020/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057021",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057024",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057025",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057042",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057046",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057055",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057059",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057062",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057066",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057075",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057077",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057080",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057080/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057080/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057081",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057092",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057097",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057110",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057112",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057112/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057112/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057113",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057121",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057127",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057127/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057127/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057128",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057128/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057128/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057129",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057137",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057141",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057161",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057164",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057164/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057164/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057165",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057165/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057165/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057166",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057174",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057174/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057174/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057175",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057175/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057175/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057176",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057176/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057176/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057177",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057182",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057184",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057189",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057189/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057189/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057190",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057194",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057206",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057206/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057206/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057207",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057207/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057207/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057208",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057208/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057208/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057209",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057212",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057214",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057217",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057217/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057217/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057218",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057220",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057220/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057220/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057221",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057221/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057221/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057222",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057226",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057228",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057230",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057235",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057235/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057235/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057236",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057240",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057240/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057240/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057241",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057241/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057241/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057242",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057245",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057247",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057247/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057247/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057248",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057248/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057248/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057249",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057256",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057256/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057256/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057257",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057257/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057257/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057258",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057258/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057258/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057259",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057259/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057259/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057260",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057270",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057275",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057275/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057275/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057281",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057296",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057296/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057296/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057304",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057304/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057304/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057306",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057306/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057306/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057311",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057311/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057311/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057317",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057322",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057322/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057322/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057324",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057324/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057324/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057325",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057325/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057325/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057326",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057326/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057326/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057327",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057327/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057327/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057328",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057330",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057331",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057331/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057331/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057332",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057332/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057332/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057333",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057333/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057333/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057334",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057337",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057338",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057340",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057342",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057342/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057342/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057343",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057343/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057343/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057344",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057344/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057344/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057345",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057348",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057348/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057348/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057349",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057349/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057349/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057350",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057350/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057350/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057351",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057351/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057351/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057352",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057352/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057352/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057353",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057353/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057353/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057354",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057354/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057354/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057355",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057355/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057355/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057356",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057356/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057356/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057357",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057362",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057363",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057363/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057363/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057364",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057364/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057364/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057365",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057365/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057365/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057366",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057366/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057366/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057367",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057367/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057367/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057368",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057372",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057372/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057372/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057373",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057373/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057373/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057374",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057374/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057374/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057375",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057375/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057375/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057377",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057377/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057377/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057378",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057378/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057378/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057379",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057379/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057379/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057380",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057382",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057383",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057383/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057383/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057384",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057384/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057384/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057385",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057387",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057388",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057390",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057390/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057390/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057391",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057391/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057391/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057392",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057392/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057392/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057393",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057393/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057393/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057394",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057394/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057394/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057395",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057397",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057397/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057397/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057398",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057398/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057398/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057399",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057399/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057399/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057400",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057400/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057400/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057401",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057401/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057401/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057402",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057402/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057402/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057403",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057405",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057407",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057407/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057407/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057408",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057408/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057408/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057409",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057409/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057409/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057410",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057410/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057410/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057411",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057411/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057411/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057412",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057412/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057412/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057413",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057416",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057416/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057416/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057417",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057417/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057417/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057418",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057418/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057418/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057419",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057419/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057419/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057420",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057420/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057420/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057421",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057421/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057421/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057422",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057422/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057422/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057423",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057423/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057423/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057424",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057424/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057424/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057425",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057425/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057425/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057426",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057426/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057426/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057427",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057427/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057427/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057428",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057428/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057428/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057429",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057431",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057432",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057432/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057432/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057433",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057433/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057433/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057434",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057436",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057436/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057436/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057437",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057437/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057437/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057438",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057438/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057438/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057439",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057439/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057439/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057440",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057440/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057440/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057441",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057443",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057445",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057445/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057445/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057446",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057446/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057446/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057447",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057447/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057447/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057448",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057448/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057448/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057449",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057449/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057449/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057450",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057452",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057452/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057452/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057453",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057453/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057453/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057454",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057454/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057454/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057455",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057455/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057455/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057456",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057456/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057456/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057457",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057457/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057457/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057458",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057460",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057460/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057460/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057461",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057461/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057461/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057462",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057462/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057462/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057463",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057463/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057463/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057464",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057464/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057464/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057465",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057465/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057465/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057466",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057466/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057466/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057467",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057467/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057467/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057468",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057468/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057468/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057469",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057469/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057469/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057470",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057470/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057470/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057471",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057471/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057471/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057472",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057472/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057472/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057473",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057473/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057473/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057474",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057474/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057474/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057475",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057477",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057477/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057477/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057478",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057478/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057478/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057479",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057479/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057479/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057480",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057480/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057480/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057481",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057481/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057481/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057482",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057482/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057482/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057483",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057483/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057483/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057484",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057484/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057484/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057485",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057485/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057485/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057486",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057486/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057486/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057487",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057487/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057487/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057488",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057488/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057488/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057489",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057489/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057489/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057490",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057490/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057490/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057491",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057491/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057491/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057492",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057492/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057492/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057493",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057493/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057493/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057494",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057494/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057494/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057497",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057497/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057497/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057498",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057498/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057498/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057499",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057499/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057499/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057500",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057500/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057500/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057501",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057501/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057501/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057502",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057504",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057505",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057505/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057505/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057506",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057506/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057506/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057507",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057507/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057507/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057508",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057508/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057508/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057509",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057509/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057509/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057510",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057510/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057510/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057511",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057511/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057511/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057512",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057512/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057512/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057513",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057513/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057513/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057514",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057514/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057514/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057515",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057515/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057515/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057516",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057516/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057516/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057521",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057521/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057521/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057522",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057522/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057522/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057523",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057523/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057523/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057524",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057526",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057527",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057527/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057527/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057528",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057528/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057528/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057529",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057529/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057529/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057530",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057530/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057530/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057531",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057533",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057533/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057533/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057534",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057534/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057534/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057535",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057535/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057535/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057536",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057536/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057536/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057537",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057537/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057537/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057538",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057538/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057538/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057539",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057539/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057539/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057540",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057540/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057540/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057542",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057542/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057542/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057543",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057543/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057543/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057544",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057544/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057544/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057545",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057545/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057545/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057546",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057548",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057549",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057549/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057549/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057550",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057550/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057550/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057551",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057551/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057551/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057552",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057552/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057552/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057553",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057553/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057553/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057554",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057554/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057554/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057555",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057555/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057555/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057556",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057556/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057556/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057557",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057557/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057557/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057560",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057560/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057560/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057562",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057562/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057562/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057563",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057565",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057566",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057566/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057566/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057567",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057567/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057567/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057568",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057568/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057568/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057569",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057569/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057569/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057570",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057570/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057570/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057572",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057572/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057572/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057573",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057573/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057573/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057574",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057574/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057574/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057575",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057575/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057575/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057576",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057576/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057576/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057577",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057579",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057580",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057582",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057584",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057584/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057584/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057585",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057587",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057587/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057587/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057588",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057588/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057588/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057589",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057589/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057589/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057590",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057593",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057593/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057593/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057594",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057594/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057594/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057595",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057595/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057595/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057596",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057596/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057596/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057597",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057597/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057597/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057598",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057598/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057598/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057599",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057599/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057599/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057600",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057602",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057602/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057602/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057603",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057603/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057603/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057604",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057604/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057604/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057605",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057605/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057605/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057606",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057606/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057606/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057607",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057607/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057607/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057608",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057608/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057608/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057609",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057609/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057609/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057610",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057610/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057610/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057611",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057611/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057611/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057612",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057612/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057612/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057613",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057613/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057613/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057614",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057614/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057614/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057615",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057615/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057615/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27057628",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393120",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393120/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393120/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393123",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393123/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393123/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393124",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393124/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393124/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393131",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393131/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393131/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393133",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393138",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393138/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393138/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393156",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393156/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393156/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393178",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393191",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393199",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393199/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393199/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393203",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393203/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393203/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393207",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393207/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393207/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393209",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393209/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393209/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393213",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393213/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393213/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393214",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393214/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393214/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393216",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393216/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393216/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393217",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393217/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393217/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393221",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393221/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393221/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393223",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393234",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393239",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393239/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393239/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393242",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393242/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393242/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393243",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393243/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393243/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393250",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393250/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393250/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393254",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393254/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393254/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393256",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393258",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393258/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393258/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393262",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393262/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393262/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393263",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393263/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393263/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393268",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393268/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393268/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393272",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393272/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393272/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393274",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393274/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393274/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393276",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393276/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393276/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393277",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393277/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393277/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393280",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393280/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393280/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393281",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393284",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393284/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393284/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393285",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393285/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393285/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393290",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393290/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393296",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393296/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393296/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393298",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393298/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393298/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393300",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393300/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393300/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393301",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393301/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393301/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393303",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393303/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393303/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393304",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393306",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393760",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393760/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393760/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393761",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393761/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393761/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393764",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393764/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393764/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393767",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393769",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393769/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393769/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393772",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393773",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393773/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393773/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393775",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393775/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393775/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393776",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393776/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393776/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393778",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393778/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393778/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393779",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393779/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393779/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393780",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393780/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393780/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393781",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393781/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393781/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393782",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393782/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393782/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393784",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393784/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393784/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393785",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393785/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393785/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393787",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393787/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393787/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393789",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393789/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393789/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393790",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393792",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393792/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393792/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393793",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393793/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393793/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393794",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393794/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393794/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393795",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393795/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393795/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393796",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393796/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393796/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393797",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393797/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393797/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn27393799",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/sad_poitras_3/thumbnail.jpg"
-    }
-
-    {
-        "synid":"syn28564179",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564180",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564188",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564193",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564197",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564201",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564202",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564204",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564205",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564208",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564212",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564213",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564216",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564220",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564221",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564226",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564227",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564230",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564232",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564233",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564234",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564239",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564242",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564251",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564253",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564269",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564270",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564275",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564279",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564284",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564301",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564306",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564330",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564350",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564376",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564381",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564393",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564441",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564494",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564516",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564520",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564528",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564538",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564542",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564549",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564552",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564554",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564566",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564569",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564581",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564584",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564585",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564602",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564608",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564611",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564614",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564616",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564621",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564625",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564630",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564644",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564645",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564649",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564658",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564664",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564666",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564671",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564675",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564677",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564693",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564694",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564702",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564703",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564705",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
-    {
-        "synid":"syn28564712",
-        "minerva":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/index.html",
-        "thumbnail":"https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
-    }
-
+  {
+    "synid": "syn24829425",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829425/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829425/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829426",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829426/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829426/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829428",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829428/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829428/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829429",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829429/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829429/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829430",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829430/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829430/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829431",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829431/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829431/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829432",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829432/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829432/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829433",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829433/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829433/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829434",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829434/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829434/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829435",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829435/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829435/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829436",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829436/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829436/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829437",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829437/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829437/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829438",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829438/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829438/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829439",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829439/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829439/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829440",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829440/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829440/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829441",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829441/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829441/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829442",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829442/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829442/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829443",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829443/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829443/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829444",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829444/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829444/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829445",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829445/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829445/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829446",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829446/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829446/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829447",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829447/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829447/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829448",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829448/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829448/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829449",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829449/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829449/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829450",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829450/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829450/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829451",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829451/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829451/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829452",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829452/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829452/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829453",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829453/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829453/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829454",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829454/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829454/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829455",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829455/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829455/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829456",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829456/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829456/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829457",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829457/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829457/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829458",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829458/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829458/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829459",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829459/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829459/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829460",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829460/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829460/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829461",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829461/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829461/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829462",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829462/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829462/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn24829463",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829463/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829463/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829464",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829464/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829464/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829465",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829465/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829465/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829466",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829466/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829466/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829467",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829467/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829467/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829468",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829468/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829468/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829469",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829469/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829469/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829470",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829470/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829470/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829471",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829471/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829471/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829472",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829472/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829472/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829473",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829473/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829473/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829474",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829474/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829474/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829475",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829475/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829475/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829476",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829476/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829476/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829477",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829477/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829477/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829478",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829478/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829478/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829479",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829479/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829479/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829480/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829480/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829481",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829481/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829481/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829482",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829482/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829482/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829483",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829483/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829483/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829484",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829484/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829484/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24829485",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829485/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24829485/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24986807",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24986807/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24986807/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992967",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992967/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992968",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992968/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992969",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992969/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992970",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992970/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992971",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992971/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992973",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992973/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992974",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992974/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992975",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992975/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992977",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992977/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992978",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992978/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992979",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992979/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992980",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992980/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992981",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992981/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992982",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992982/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992983",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992983/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992984",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992984/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992985",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992985/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992986",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992986/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992987",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992987/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992988",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992988/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992989",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992989/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992990",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992990/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992991",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992991/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992992",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992992/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992993",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992993/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992994",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992994/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992996",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992996/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992997",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992997/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992998",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992998/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24992999",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24992999/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993000",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993000/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993001",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993001/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993002",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993002/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993003",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993003/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993005",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993005/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993007",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993007/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993008",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993008/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993009",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993009/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993010",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993010/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993011",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993011/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993012",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993012/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993013",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993013/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993014",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993014/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993016",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993016/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993017",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993017/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993018",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993018/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993019",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993019/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993020",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993020/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993021",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993021/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993022",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993022/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993023",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993023/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993024",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993024/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993025",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993025/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993026",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993026/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993027",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993027/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993029",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993029/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993031",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993031/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993032",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993032/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993033",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993033/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993034",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993034/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993035",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993035/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993036",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993036/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993037",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993037/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993039",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993039/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993040",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993040/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993046",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993046/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993048",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993048/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993050",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993050/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993057",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993057/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993063",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993063/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn24993069",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn24993069/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25054776",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25054776/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25054776/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25055566",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055566/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055566/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25055737",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055737/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055737/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25055797",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055797/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25055797/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25056191",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056191/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056191/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25056480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056480/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056480/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25056808",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056808/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25056808/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25057095",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057095/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057095/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25057262",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057262/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25057262/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25058438",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25058438/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25058438/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25059248",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059248/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059248/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25059795",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059795/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059795/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25059811",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059811/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25059811/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25060020",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060020/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060020/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25060047",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060047/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060047/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25060077",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060077/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25060077/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25068083",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25068083/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25068083/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25070310",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070310/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070310/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25070644",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070644/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25070644/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25071129",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071129/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071129/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25071714",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071714/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071714/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25071769",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071769/elated_poisson/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071769/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25071777",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071777/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25071777/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25072720",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25072720/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25072779",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25072779/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25073076",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25073076/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25073076/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25074523",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074523/nasty_ekeblad/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074523/nasty_ekeblad/thumbnail.png"
+  },
+  {
+    "synid": "syn25074974",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074974/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25074976",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074976/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25074996",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25074996/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075278",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075278/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075282",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075282/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075311",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075311/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075365",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075365/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075398",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075398/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075400",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075400/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075411",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075411/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075415",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075415/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075429",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075429/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075431",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075431/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075475",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075475/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075480/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075484",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075484/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075487",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/big_panini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075487/nasty_ekeblad/thumbnail.png"
+  },
+  {
+    "synid": "syn25075505",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075505/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075516",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075516/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075529",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075529/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075561",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075561/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075587",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075587/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075636",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075636/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25075664",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075664/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075664/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25075713",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075713/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25075782",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075782/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075869",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075869/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075875",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075875/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075901",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075901/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075912",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075912/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075926",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075926/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25075948",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25075948/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076001",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076001/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076004",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076004/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076014",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076014/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076021",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076021/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076038",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076038/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076062",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076062/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076096",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076096/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076108",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076108/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076147",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076147/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076156",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076156/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076184",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076184/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076268",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076268/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076369",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076369/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25076441",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076441/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076572",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076572/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076608",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076608/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25076711",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25076711/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25077585",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077585/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077585/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077641",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077641/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077641/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077680",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077680/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077680/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077727",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077727/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077727/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077777",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077777/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077839",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077839/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077877",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077877/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077877/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077900",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077900/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077900/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077940",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077940/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077940/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25077960",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077960/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25077960/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25078332",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25078332/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25078512",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25078512/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25079158",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25079158/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25079158/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25080543",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080543/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080543/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25080595",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080595/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25080720",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080720/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25080720/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25081236",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081236/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25081468",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081468/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25081468/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25082605",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25082605/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25083176",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083176/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083176/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25083552",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25083552/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25114909",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25114909/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25115882",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25115882/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25117091",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25117091/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn25547790",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547790/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547790/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547793",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547793/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547794",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html"
+  },
+  {
+    "synid": "syn25547796",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547797",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547798",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547798/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547798/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547800",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547801",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547802",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547803",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547803/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547803/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547805",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547805/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547805/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547806",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547806/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547806/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547808",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547808/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547809",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547809/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547811",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547812",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547812/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547812/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547814",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547815",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547815/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25547816",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547816/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547817",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547817/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547817/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547818",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/naughty_rubens/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547818/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547819",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547819/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547819/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547820",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547820/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547821",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547822",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547822/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547822/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547823",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547824",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547825",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547825/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547825/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547826",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25547827",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547827/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25547828",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547828/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25665299",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665299/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665299/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25665424",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665424/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665424/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25665553",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665553/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665553/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25665640",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665640/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665640/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25665766",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665766/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665766/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25665870",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665870/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25665870/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666058",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666058/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666058/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666170",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666170/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666170/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666276",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666276/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666276/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666409",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666409/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666409/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666476",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666476/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666476/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666622",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666622/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666622/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666713",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666713/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666713/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666775",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666775/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666775/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25666862",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666862/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25666862/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701019",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701019/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701020",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701020/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701023",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701023/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701025",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701025/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701026",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701026/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701030",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701030/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701033",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701033/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701036",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701036/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701038",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701038/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701040",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701040/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701043",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701043/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701044",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701044/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701046",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701046/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701048",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701048/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701050",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701050/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701052",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701052/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701055",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701055/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701056",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701056/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701058",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701058/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701060",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701060/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701064",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701064/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701066",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701066/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701069",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701069/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701071",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701071/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701073",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701073/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701077",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701077/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701078",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701078/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701081",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701081/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701083",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701083/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701085",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701085/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701087",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701087/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701089",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701089/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701092",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701092/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701094",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701094/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701097",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701097/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701100",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701100/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701102",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701102/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701104",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701104/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701106",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701106/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701108",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701108/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701110",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701110/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701112",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701112/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701114",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701114/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701116",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701116/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25701118",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701118/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701120",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701120/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701122",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701122/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701126",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701126/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701128",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701128/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701131",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701131/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701133",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701133/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701136",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701136/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701140",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701140/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701142",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701142/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701145",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701145/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701146",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701146/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701149",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701149/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701151",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701151/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701154",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701154/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701156",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701156/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701159",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701159/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25701162",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701162/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701164",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701164/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701166",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701166/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701168",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701168/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701170",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701170/stoic_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25701172",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701172/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701174",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701174/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701176",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701176/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701179",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701179/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701180",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701180/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701182",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701182/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701184",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701184/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701188",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701188/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701190",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701190/kickass_mirzakhani/thumbnail.png"
+  },
+  {
+    "synid": "syn25701193",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701193/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701195",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701195/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25701198",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25701198/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25757216",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25757216/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn25871033",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871034",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871035",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871036",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871036/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871037",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871038",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871039",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871040",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871042",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html"
+  },
+  {
+    "synid": "syn25871043",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871046",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871048",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871048/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871048/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871049",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871049/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871052",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871052/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871056",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871061",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871061/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871061/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871063",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871063/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871063/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871069",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871069/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871069/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871070",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871071",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871071/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871071/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871072",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871072/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871073",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/naughty_rubens/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871073/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25871074",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871074/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871074/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871075",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871075/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871075/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871076",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871076/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871076/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871078",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871078/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871078/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871079",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871079/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871079/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871080",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871081",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871081/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871081/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871082",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871082/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871083",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871083/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871083/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871084",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871084/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25871085",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871086",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871087",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871087/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871089",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871090",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871091",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871092",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871093",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871094",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871094/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871094/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871096",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871097",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871098",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871099",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871100",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871101",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871114",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871117",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871118",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871118/big_panini/thumbnail.png"
+  },
+  {
+    "synid": "syn25871119",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871121",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871122",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871123",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871123/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871123/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871124",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871125",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871126",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871126/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871126/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871129",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871130",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871132",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871132/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871132/loving_swartz_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25871133",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871139",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871140",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871143",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871147",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25871148",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/index.html"
+  },
+  {
+    "synid": "syn25874083",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874083/confident_shaw_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874083/confident_shaw_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25874084",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874084/confident_shaw_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874084/confident_shaw_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25874088",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874088/confident_shaw_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874088/confident_shaw_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25874089",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874089/confident_shaw_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874089/confident_shaw_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25874099",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874099/confident_shaw_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874099/confident_shaw_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25874101",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874101/confident_shaw_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25874101/confident_shaw_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882267",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882267/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882268",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882268/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882269",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882269/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882270",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882270/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882273",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882273/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882275",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882275/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882276",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882276/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882277",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882277/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882282",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882282/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882289",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882289/awesome_baekeland_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882315",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882315/confident_shaw_3/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882315/confident_shaw_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn25882965",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882965/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882965/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25882990",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882990/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25882990/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883086",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883086/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883086/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883126",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883126/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883126/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883141",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883141/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883141/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883160",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883160/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883160/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883246",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883246/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883246/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883274",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883274/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883295",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883295/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883295/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883318",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883318/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883318/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883326",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883326/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883326/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883365",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883365/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883365/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883382",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883382/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883382/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883391",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883391/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883391/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883395",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883395/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883405",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883405/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883416",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883416/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883416/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25883433",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883433/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25883433/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn25884288",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25884288/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25884288/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26344274",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344274/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344274/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344275",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344275/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344275/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344276",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344276/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344276/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344277",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344277/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344277/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344278",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344278/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344278/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344279",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344279/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344279/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344280",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344280/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344280/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344281",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344281/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344281/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344282",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344282/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344282/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344283",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344283/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344283/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344284",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344284/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344284/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344285",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344285/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344285/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344286",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344286/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344286/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344287",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344287/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344287/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344288",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344288/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344288/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344289",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344289/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344289/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344290",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344290/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344290/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344291",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344291/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344291/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344292",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344292/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344292/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344293",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344293/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344293/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344294",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344294/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344294/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344295",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344295/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344295/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344296",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344296/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344296/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344297",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344297/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344297/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344298",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344298/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344298/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344299",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344299/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344299/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344300",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344300/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344300/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344301",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344301/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344301/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344302",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344302/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344302/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344303",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344303/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344303/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344304",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344304/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344304/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344305",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344305/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344305/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344306",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344306/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344306/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344307",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344307/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344307/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344308",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344308/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344308/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344309",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344309/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344309/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344310",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344310/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344310/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344311",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344311/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344311/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344312",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344312/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344312/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344313",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344313/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344313/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344314",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344314/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344314/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344315",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344315/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344315/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344316",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344316/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344316/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344317",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344317/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344317/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344318",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344318/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344318/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344319",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344319/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344319/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344320",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344320/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344320/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344321",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344321/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344321/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344322",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344322/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344322/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344323",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344323/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344323/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344324",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344324/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344324/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344325",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344325/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344325/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344326",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344326/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344326/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344327",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344327/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344327/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344328",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344328/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344328/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344329",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344329/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344329/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344330",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344330/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344330/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26344331",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344331/hungry_montalcini/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26344331/hungry_montalcini/thumbnail.png"
+  },
+  {
+    "synid": "syn26445552",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445552/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445552/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26445553",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445553/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445553/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26445554",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445554/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445554/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26445555",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445555/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445555/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26445556",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445556/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445556/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26445557",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445557/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445557/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26445558",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445558/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445558/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26445559",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445559/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26445559/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452482",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452482/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452482/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452504",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452504/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452504/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452505",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452505/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452505/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452508",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452508/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452508/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452509",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452509/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452509/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452510",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452510/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452510/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452511",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452511/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452511/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452512",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452512/golden_leavitt/thumbnail.png"
+  },
+  {
+    "synid": "syn26452513",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452513/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452513/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452523",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452523/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452523/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452527",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452527/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452527/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26452529",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26452529/v1/thumbnail.png"
+  },
+  {
+    "synid": "syn26466814",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466814/golden_leavitt/thumbnail.png"
+  },
+  {
+    "synid": "syn26466819",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466819/golden_leavitt/thumbnail.png"
+  },
+  {
+    "synid": "syn26466822",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26466822/golden_leavitt/thumbnail.png"
+  },
+  {
+    "synid": "syn26486747",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486747/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486749",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486749/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486751",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486751/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486754",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486754/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486755",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486755/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486757",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486757/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486759",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486759/nasty_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486771",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486771/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486773",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486773/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486775",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486775/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486777",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486777/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486779",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486779/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486781",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486781/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486783",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486783/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486785",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486785/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486787",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486787/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486789",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486789/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486791",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486791/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26486793",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26486793/admiring_bohr/thumbnail.png"
+  },
+  {
+    "synid": "syn26529074",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529074/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529074/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26529076",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26529076/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26535446",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535446/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535446/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535455",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535455/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535455/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535456",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535456/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535456/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535472",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535472/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535472/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535474",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535474/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535474/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535475",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535475/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535475/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535479",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535479/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535479/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535480/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535480/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535481",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535481/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535481/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535483",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535483/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535483/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535495",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535495/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535495/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535498",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535498/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535498/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535499",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535499/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535499/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535516",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535516/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535516/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535526",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535526/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535526/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535533",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535533/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535533/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535552",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535552/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535552/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535554",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535554/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535554/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535557",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535557/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535557/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535559",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535559/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535559/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535567",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535567/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535567/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535569",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535569/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535569/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535570",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535570/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535570/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535573",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535573/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535573/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535575",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535575/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535575/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26535577",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535577/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26535577/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26536222",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536222/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536222/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26536228",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536228/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536228/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26536297",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536297/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536297/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26536908",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536908/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26536908/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537079",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537079/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537079/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537170",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537170/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537170/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537238",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537238/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537238/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537370",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537370/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537370/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537407",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537407/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537407/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537420",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537420/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537420/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537450",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537450/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537450/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537466",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537466/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537466/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537467",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537467/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537467/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537476",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537476/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537476/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537480/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537480/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537487",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537487/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537487/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537505",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537505/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537505/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537507",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537507/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537507/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537514",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537514/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537514/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26537519",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537519/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26537519/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn26642471",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642471/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642471/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642472",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642472/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642472/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642481",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642481/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642481/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642482",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642482/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642482/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642484",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642484/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642484/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642485",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642485/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642485/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642486",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642486/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642486/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642487",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642487/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642487/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642488",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642488/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642488/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642489",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642489/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642489/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642490",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642490/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642490/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642491",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642491/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642491/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642494",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642494/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642494/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642495",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642495/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642495/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642496",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642496/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642496/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642497",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642497/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642497/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642500",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642500/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642500/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642501",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642501/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642501/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642502",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642502/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642502/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642503",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642503/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642503/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642504",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642504/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642504/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642506",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642506/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642506/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642507",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642507/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642507/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642508",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642508/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642508/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642509",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642509/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642509/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642510",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642510/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642510/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642511",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642511/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642511/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642512",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642512/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642512/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642513",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642513/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642513/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642514",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642514/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642514/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26642515",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642515/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26642515/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26643894",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643894/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn26643896",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26643896/lonely_coulomb/thumbnail.png"
+  },
+  {
+    "synid": "syn26644414",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644414/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644416",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644416/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644421",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644421/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644422",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644422/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644423",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644423/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644426",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644426/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644427",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644427/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644428",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644428/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644429",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644429/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644430",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644430/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644431",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644431/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644432",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644432/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644433",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644433/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644434",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644434/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644435",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644435/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644436",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644436/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644437",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644437/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644438",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644438/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644439",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644439/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644440",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644440/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644441",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644441/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644442",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644442/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644443",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644443/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644444",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644444/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644445",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644445/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644446",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644446/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644447",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644447/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644448",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644448/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644449",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644449/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644450",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644450/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644451",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644451/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644452",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644452/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644453",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644453/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644454",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644454/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644455",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644455/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644456",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644456/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644457",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644457/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644458",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644458/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644459",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644459/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644460",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644460/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644461",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644461/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644462",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644462/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644463",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644463/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644464",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644464/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644465",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644465/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644466",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644466/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644467",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644467/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644468",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644468/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644469",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644469/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644470",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644470/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644471",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644471/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644472",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644472/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644473",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644473/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644474",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644474/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644475",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644475/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644476",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644476/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644477",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644477/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644478",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644478/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644479",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644479/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644480/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644481",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644481/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644482",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644482/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644483",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644483/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644484",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644484/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644485",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644485/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644486",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644486/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644487",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644487/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644488",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644488/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644489",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644489/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644490",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644490/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644491",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644491/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644492",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644492/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644493",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644493/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644494",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644494/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644495",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644495/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644496",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644496/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644497",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644497/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644498",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644498/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644499",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644499/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644500",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644500/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644501",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644501/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644502",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644502/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644503",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644503/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644504",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644504/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644505",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644505/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644506",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644506/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644507",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644507/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644508",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644508/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644509",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644509/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644510",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644510/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644511",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644511/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644512",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644512/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644513",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644513/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644514",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644514/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644515",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644515/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644516",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644516/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644517",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644517/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644518",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644518/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644519",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644519/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644520",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644520/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644521",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644521/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644522",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644522/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644523",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644523/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644524",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644524/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644525",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644525/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644526",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644526/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644527",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644527/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644528",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644528/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644529",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644529/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644530",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644530/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644531",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644531/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644532",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644532/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644533",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644533/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644534",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644534/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644535",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644535/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644536",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644536/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644537",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644537/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644538",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644538/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644539",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644539/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644540",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644540/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644541",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644541/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644542",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644542/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644543",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644543/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644544",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644544/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644545",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644545/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644546",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644546/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644547",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644547/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644548",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644548/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644549",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644549/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644550",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644550/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644551",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644551/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644552",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644552/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644553",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644553/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644554",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644554/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644555",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644555/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644556",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644556/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644557",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644557/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644558",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644558/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644559",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644559/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644560",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644560/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644561",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644561/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644562",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644562/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644563",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644563/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644564",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644564/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644565",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644565/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644566",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644566/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644567",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644567/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644568",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644568/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644569",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644569/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644570",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644570/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644571",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644571/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644572",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644572/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644573",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644573/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644574",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644574/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644575",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644575/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644576",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644576/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644577",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644577/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644578",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644578/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644579",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644579/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644580",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644580/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644581",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644581/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644582",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644582/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644583",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644583/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644584",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644584/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644585",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644585/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644586",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644586/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644587",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644587/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644588",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644588/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644589",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644589/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644590",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644590/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644591",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644591/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644592",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644592/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644593",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644593/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644594",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644594/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644595",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644595/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644596",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644596/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644597",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644597/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644598",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644598/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644599",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644599/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644600",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644600/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644601",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644601/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644602",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644602/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644603",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644603/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644604",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644604/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644605",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644605/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644606",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644606/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644607",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644607/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644608",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644608/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644609",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644609/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644610",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644610/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644611",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644611/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644612",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644612/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644613",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644613/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644614",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644614/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644615",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644615/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644616",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644616/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644617",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644617/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644618",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644618/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644619",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644619/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644620",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644620/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644621",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644621/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644622",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644622/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644625",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644625/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644626",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644626/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644627",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644627/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644628",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644628/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644629",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644629/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644630",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644630/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644631",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644631/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644632",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644632/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644633",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644633/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644634",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644634/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644635",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644635/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644636",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644636/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644637",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644637/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644638",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644638/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644639",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644639/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644640",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644640/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644641",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644641/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644642",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644642/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644643",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644643/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644644",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644644/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644645",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644645/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644646",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644646/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644647",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644647/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644648",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644648/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644649",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644649/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644650",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644650/naughty_torricelli/thumbnail.png"
+  },
+  {
+    "synid": "syn26644651",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644651/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644652",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644652/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644653",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644653/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644654",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644654/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644655",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644655/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644656",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644656/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644657",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644657/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644658",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644658/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644659",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644659/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644660",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644660/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644661",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644661/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644662",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644662/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644663",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644663/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644664",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644664/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644665",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644665/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644666",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644666/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644667",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644667/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644668",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644668/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644669",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644669/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644670",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644670/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644671",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644671/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644672",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644672/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644673",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644673/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644674",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644674/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644675",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644675/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644676",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644676/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644677",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644677/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644678",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644678/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644679",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644679/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644680",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644680/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644681",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644681/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644682",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644682/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644683",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644683/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644684",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644684/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644685",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644685/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644686",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644686/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644687",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644687/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644688",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644688/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644689",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644689/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644690",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644690/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644691",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644691/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644692",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644692/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644693",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644693/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644694",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644694/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644695",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644695/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644696",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644696/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644697",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644697/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644698",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644698/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644699",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644699/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644700",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644700/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644701",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644701/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644702",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644702/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644703",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644703/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644704",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644704/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644705",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644705/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644706",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644706/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644707",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644707/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644708",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644708/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644709",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644709/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644710",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644710/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644711",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644711/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644712",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644712/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644713",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644713/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644714",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644714/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644715",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644715/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644716",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644716/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644717",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644717/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644718",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644718/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644719",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644719/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644720",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644720/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644721",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644721/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644722",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644722/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644723",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644723/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644724",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644724/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644725",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644725/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644726",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644726/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644727",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644727/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644728",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644728/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644729",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644729/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644730",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644730/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644731",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644731/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644732",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644732/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644733",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644733/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644734",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644734/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644735",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644735/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644736",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644736/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644737",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644737/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644738",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644738/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644739",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644739/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644740",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644740/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644741",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644741/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644742",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644742/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644743",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644743/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644744",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644744/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644745",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644745/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644746",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644746/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644747",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644747/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644748",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644748/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644749",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644749/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26644750",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/high_franklin/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26644750/high_franklin/thumbnail.png"
+  },
+  {
+    "synid": "syn26937643",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937643/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937644",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937644/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937645",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937645/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937646",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937646/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937647",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937647/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937648",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937648/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937649",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937649/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937650",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937650/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937651",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937651/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937652",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937652/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937653",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937653/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937654",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937654/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937655",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937655/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937656",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937656/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937657",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937657/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937658",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937658/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937659",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937659/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937660",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937660/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937661",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937661/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937662",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937662/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937663",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937663/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937664",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937664/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937665",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937665/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937666",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937666/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937667",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937667/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937668",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937668/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937669",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937669/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937670",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937670/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937671",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937671/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937672",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937672/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937673",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937673/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937674",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937674/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937675",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937675/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937676",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937676/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937677",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937677/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937678",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937678/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937679",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937679/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937680",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937680/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937681",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937681/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937696",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937696/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937697",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937697/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937730",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937730/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937748",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937748/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937756",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937756/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937757",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937757/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937758",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937758/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937759",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937759/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937760",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937760/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937761",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937761/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937762",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937762/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937763",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937763/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937764",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937764/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937765",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937765/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937766",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937766/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937767",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937767/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937768",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937768/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937769",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937769/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937770",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937770/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937771",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937771/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937772",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937772/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937773",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937773/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937774",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937774/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937775",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937775/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937776",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937776/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937777",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937777/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937778",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937778/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937779",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937779/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937780",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937780/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937781",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937781/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937782",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937782/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937783",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937783/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937784",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937784/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937785",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937785/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937786",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937786/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937787",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937787/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937788",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937788/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937789",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937789/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937790",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937790/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937791",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937791/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937792",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937792/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937793",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937793/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937802",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937802/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937803",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937803/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937804",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937804/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937836",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937836/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937859",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937859/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937860",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937860/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937861",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937861/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937862",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937862/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937863",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937863/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937864",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937864/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937865",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937865/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937866",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937866/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937867",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937867/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937868",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937868/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937869",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937869/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937870",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937870/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937871",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937871/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937872",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937872/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937873",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937873/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937874",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937874/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937875",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937875/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937876",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937876/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937877",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937877/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937878",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937878/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937879",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937879/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937880",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937880/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937881",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937881/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937882",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937882/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937883",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937883/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937884",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937884/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937885",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937885/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937886",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937886/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937887",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937887/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937888",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937888/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937889",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937889/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937890",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937890/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937891",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937891/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937892",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937892/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937893",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937893/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937894",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937894/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937895",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937895/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937896",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937896/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937911",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937911/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937912",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937912/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937950",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937950/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937969",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937969/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937971",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937971/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937972",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937972/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937973",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937973/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937974",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937974/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937975",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937975/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937976",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937976/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937977",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937977/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937978",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937978/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937979",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937979/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937980",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937980/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937981",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937981/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937982",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937982/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937983",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937983/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937984",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937984/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937985",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937985/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937986",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937986/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937987",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937987/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937988",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937988/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937989",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937989/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937990",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937990/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937991",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937991/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937992",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937992/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937994",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937994/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937995",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937995/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937997",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937997/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26937999",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26937999/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26938001",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26938001/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn26940250",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/high_mendel/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn26940250/magical_cori/thumbnail.png"
+  },
+  {
+    "synid": "syn27021863",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056837",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056837/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056838",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056838/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056839",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056839/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056840",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056841",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056841/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056841/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056842",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056842/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056842/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056843",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056844",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056844/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056845",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056845/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056846",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056847",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056848",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056848/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056849",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056850",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056850/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056851",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056851/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056852",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056852/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056852/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056853",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056854",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056854/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056855",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056856",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056856/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056857",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056857/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056857/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056858",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056858/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056858/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056859",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056859/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056859/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056860",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056861",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056861/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056862",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056863",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056863/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056864",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056864/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056865",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056865/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056866",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056866/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056866/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056867",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056867/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056867/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056868",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056869",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056869/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056870",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056870/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056875",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056875/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056893",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056894",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056895",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056895/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056896",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056897",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056897/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056908",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056908/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056908/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056912",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056913",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056913/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056914",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056914/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056915",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056915/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056919",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056919/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056920",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056921",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056921/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056922",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056922/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056922/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056923",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056925",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056925/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056926",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056926/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056927",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056928",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056928/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056929",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056930",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056930/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056931",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056931/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056932",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056932/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056933",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056933/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056934",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056934/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056935",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056935/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056936",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056936/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056937",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056937/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056937/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056938",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056938/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056938/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056939",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056940",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056940/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056941",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056941/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056942",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056942/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056943",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056943/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056944",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056944/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056945",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056946",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056946/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056947",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056947/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056948",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056948/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056949",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056949/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056950",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056950/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056950/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056952",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056953",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056953/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056954",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056954/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056955",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056956",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056956/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056957",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056957/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056958",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056958/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056959",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056959/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056960",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056960/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056960/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056961",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056962",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056962/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056963",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056964",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056964/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056965",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056965/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056965/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056966",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056966/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056966/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056967",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056968",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056968/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056969",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056969/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056970",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056970/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056970/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056971",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056971/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056971/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056972",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056972/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056972/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056973",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056974",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056974/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056975",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056975/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056976",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056976/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056977",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056977/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056978",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056978/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056979",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056979/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056984",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056984/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056985",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056985/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056987",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056987/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056988",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056988/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056988/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056989",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056989/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056989/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056990",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056990/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056990/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056991",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056991/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056991/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056992",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27056993",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056993/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056994",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056994/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056995",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056995/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056996",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056996/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056997",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056997/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056998",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056998/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27056999",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057000",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057000/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057000/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057001",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057002",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057002/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057004",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057005",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057006",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057006/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057007",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057007/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057008",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057009",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057009/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057010",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057010/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057011",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057011/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057012",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057012/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057013",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057013/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057014",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057015",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057015/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057016",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057017",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057017/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057018",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057018/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057019",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057019/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057020",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057020/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057020/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057021",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057022",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057022/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057023",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057023/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057024",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057025",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057027",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057027/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057028",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057028/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057029",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057029/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057030",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057030/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057031",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057031/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057032",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057032/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057033",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057033/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057034",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057034/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057035",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057035/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057036",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057036/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057038",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057038/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057039",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057039/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057040",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057040/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057041",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057041/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057042",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057043",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057043/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057044",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057044/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057045",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057045/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057046",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057047",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057047/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057048",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057048/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057049",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057049/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057050",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057050/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057051",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057051/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057052",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057052/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057053",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057053/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057054",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057054/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057055",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057056",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057056/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057058",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057058/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057059",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057060",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057060/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057061",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057061/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057062",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057063",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057063/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057064",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057064/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057065",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057065/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057066",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057067",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057067/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057068",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057068/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057069",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057069/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057070",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057070/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057071",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057071/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057072",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057072/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057073",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057073/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057074",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057074/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057075",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057076",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057076/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057077",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057078",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057078/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057079",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057079/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057080",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057080/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057080/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057081",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057082",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057082/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057083",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057083/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057084",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057084/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057085",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057085/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057086",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057086/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057087",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057087/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057088",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057088/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057089",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057089/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057090",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057090/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057091",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057091/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057092",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057093",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057093/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057094",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057094/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057095",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057095/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057096",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057096/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057097",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057098",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057098/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057099",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057099/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057100",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057100/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057101",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057101/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057102",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057102/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057103",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057103/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057104",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057104/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057105",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057105/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057106",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057106/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057107",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057107/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057108",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057108/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057109",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057109/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057110",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057111",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057111/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057112",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057112/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057112/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057113",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057114",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057114/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057115",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057115/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057118",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057118/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057119",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057119/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057120",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057120/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057121",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057122",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057122/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057123",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057123/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057124",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057124/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057125",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057125/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057126",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057126/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057127",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057127/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057127/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057128",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057128/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057128/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057129",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057130",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057130/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057131",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057131/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057132",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057132/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057133",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057133/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057134",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057134/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057135",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057135/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057136",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057136/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057137",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057138",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057138/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057139",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057139/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057140",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057140/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057141",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057142",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057142/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057143",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057143/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057144",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057144/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057145",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057145/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057146",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057146/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057147",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057147/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057149",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057149/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057150",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057150/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057151",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057151/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057152",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057152/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057153",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057153/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057154",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057154/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057155",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057155/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057156",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057156/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057157",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057157/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057158",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057158/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057159",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057159/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057160",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057160/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057161",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057162",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057162/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057163",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057163/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057164",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057164/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057164/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057165",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057165/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057165/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057166",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057167",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057167/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057168",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057168/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057169",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057169/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057170",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057170/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057171",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057171/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057172",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057172/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057173",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057173/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057174",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057174/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057174/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057175",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057175/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057175/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057176",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057176/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057176/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057177",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057178",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057178/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057179",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057179/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057180",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057180/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057181",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057181/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057182",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057183",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057183/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057184",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057185",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057185/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057186",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057186/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057187",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057187/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057188",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057188/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057189",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057189/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057189/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057190",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057191",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057191/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057192",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057192/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057193",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057193/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057194",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057195",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057195/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057198",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057198/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057199",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057199/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057200",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057200/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057201",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057201/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057202",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057202/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057203",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057203/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057204",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057204/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057205",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057205/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057206",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057206/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057206/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057207",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057207/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057207/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057208",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057208/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057208/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057209",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057210",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057210/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057211",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057211/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057212",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057213",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057213/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057214",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057215",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057215/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057216",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057216/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057217",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057217/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057217/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057218",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057219",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057219/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057220",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057220/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057220/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057221",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057221/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057221/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057222",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057223",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057223/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057224",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057224/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057225",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057225/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057226",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057227",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057227/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057228",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057229",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057229/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057230",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057231",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057231/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057232",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057232/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057233",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057233/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057234",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057234/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057235",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057235/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057235/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057236",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057237",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057237/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057238",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057238/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057239",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057239/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057240",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057240/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057240/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057241",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057241/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057241/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057242",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057243",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057243/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057244",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057244/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057245",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057246",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057246/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057247",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057247/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057247/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057248",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057248/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057248/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057249",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057250",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057250/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057251",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057251/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057252",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057252/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057256",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057256/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057256/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057257",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057257/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057257/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057258",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057258/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057258/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057259",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057259/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057259/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057260",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057261",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057261/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057262",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057262/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057263",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057263/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057264",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057264/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057270",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057273",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057273/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057275",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057275/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057275/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057281",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057289",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057289/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057296",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057296/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057296/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057304",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057304/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057304/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057306",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057306/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057306/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057311",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057311/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057311/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057317",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057318",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057318/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057322",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057322/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057322/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057324",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057324/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057324/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057325",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057325/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057325/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057326",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057326/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057326/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057327",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057327/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057327/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057328",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057329",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057329/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057330",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057331",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057331/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057331/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057332",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057332/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057332/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057333",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057333/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057333/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057334",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057335",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057335/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057336",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057336/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057337",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057338",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057339",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057339/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057340",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057341",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057341/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057342",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057342/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057342/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057343",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057343/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057343/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057344",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057344/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057344/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057345",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057346",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057346/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057347",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057347/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057348",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057348/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057348/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057349",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057349/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057349/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057350",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057350/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057350/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057351",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057351/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057351/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057352",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057352/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057352/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057353",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057353/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057353/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057354",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057354/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057354/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057355",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057355/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057355/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057356",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057356/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057356/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057357",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057358",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057358/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057362",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057363",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057363/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057363/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057364",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057364/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057364/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057365",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057365/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057365/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057366",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057366/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057366/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057367",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057367/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057367/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057368",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057370",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057370/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057371",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057371/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057372",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057372/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057372/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057373",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057373/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057373/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057374",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057374/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057374/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057375",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057375/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057375/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057377",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057377/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057377/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057378",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057378/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057378/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057379",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057379/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057379/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057380",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057381",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057381/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057382",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057383",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057383/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057383/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057384",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057384/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057384/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057385",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057386",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057386/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057387",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057388",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057389",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057389/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057390",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057390/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057390/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057391",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057391/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057391/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057392",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057392/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057392/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057393",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057393/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057393/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057394",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057394/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057394/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057395",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057396",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057396/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057397",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057397/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057397/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057398",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057398/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057398/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057399",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057399/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057399/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057400",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057400/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057400/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057401",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057401/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057401/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057402",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057402/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057402/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057403",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057404",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057404/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057405",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057406",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057406/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057407",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057407/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057407/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057408",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057408/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057408/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057409",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057409/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057409/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057410",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057410/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057410/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057411",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057411/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057411/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057412",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057412/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057412/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057413",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057414",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057414/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057415",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057415/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057416",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057416/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057416/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057417",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057417/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057417/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057418",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057418/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057418/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057419",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057419/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057419/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057420",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057420/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057420/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057421",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057421/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057421/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057422",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057422/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057422/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057423",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057423/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057423/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057424",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057424/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057424/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057425",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057425/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057425/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057426",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057426/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057426/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057427",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057427/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057427/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057428",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057428/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057428/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057429",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057430",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057430/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057431",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057432",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057432/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057432/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057433",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057433/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057433/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057434",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057435",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057435/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057436",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057436/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057436/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057437",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057437/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057437/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057438",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057438/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057438/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057439",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057439/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057439/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057440",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057440/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057440/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057441",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057442",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057442/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057443",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057444",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057444/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057445",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057445/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057445/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057446",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057446/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057446/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057447",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057447/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057447/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057448",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057448/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057448/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057449",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057449/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057449/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057450",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057451",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057451/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057452",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057452/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057452/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057453",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057453/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057453/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057454",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057454/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057454/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057455",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057455/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057455/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057456",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057456/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057456/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057457",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057457/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057457/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057458",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057459",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057459/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057460",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057460/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057460/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057461",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057461/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057461/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057462",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057462/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057462/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057463",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057463/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057463/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057464",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057464/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057464/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057465",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057465/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057465/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057466",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057466/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057466/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057467",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057467/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057467/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057468",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057468/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057468/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057469",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057469/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057469/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057470",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057470/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057470/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057471",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057471/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057471/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057472",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057472/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057472/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057473",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057473/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057473/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057474",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057474/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057474/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057475",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057476",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057476/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057477",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057477/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057477/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057478",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057478/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057478/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057479",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057479/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057479/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057480",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057480/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057480/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057481",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057481/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057481/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057482",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057482/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057482/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057483",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057483/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057483/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057484",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057484/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057484/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057485",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057485/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057485/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057486",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057486/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057486/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057487",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057487/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057487/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057488",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057488/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057488/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057489",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057489/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057489/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057490",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057490/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057490/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057491",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057491/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057491/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057492",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057492/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057492/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057493",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057493/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057493/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057494",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057494/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057494/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057497",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057497/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057497/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057498",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057498/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057498/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057499",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057499/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057499/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057500",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057500/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057500/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057501",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057501/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057501/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057502",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057503",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057503/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057504",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057505",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057505/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057505/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057506",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057506/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057506/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057507",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057507/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057507/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057508",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057508/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057508/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057509",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057509/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057509/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057510",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057510/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057510/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057511",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057511/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057511/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057512",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057512/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057512/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057513",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057513/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057513/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057514",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057514/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057514/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057515",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057515/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057515/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057516",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057516/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057516/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057521",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057521/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057521/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057522",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057522/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057522/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057523",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057523/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057523/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057524",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057525",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057525/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057526",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057527",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057527/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057527/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057528",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057528/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057528/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057529",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057529/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057529/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057530",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057530/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057530/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057531",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057532",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057532/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057533",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057533/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057533/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057534",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057534/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057534/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057535",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057535/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057535/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057536",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057536/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057536/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057537",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057537/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057537/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057538",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057538/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057538/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057539",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057539/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057539/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057540",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057540/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057540/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057542",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057542/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057542/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057543",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057543/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057543/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057544",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057544/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057544/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057545",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057545/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057545/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057546",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057547",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057547/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057548",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057549",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057549/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057549/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057550",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057550/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057550/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057551",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057551/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057551/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057552",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057552/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057552/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057553",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057553/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057553/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057554",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057554/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057554/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057555",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057555/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057555/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057556",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057556/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057556/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057557",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057557/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057557/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057560",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057560/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057560/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057562",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057562/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057562/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057563",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057564",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057564/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057565",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057566",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057566/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057566/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057567",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057567/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057567/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057568",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057568/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057568/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057569",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057569/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057569/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057570",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057570/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057570/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057572",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057572/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057572/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057573",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057573/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057573/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057574",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057574/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057574/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057575",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057575/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057575/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057576",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057576/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057576/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057577",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057578",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057578/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057579",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057580",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057581",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057581/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057582",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057583",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057583/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057584",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057584/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057584/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057585",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057586",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057586/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057587",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057587/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057587/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057588",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057588/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057588/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057589",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057589/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057589/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057590",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057591",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057591/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057592",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057592/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057593",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057593/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057593/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057594",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057594/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057594/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057595",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057595/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057595/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057596",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057596/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057596/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057597",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057597/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057597/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057598",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057598/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057598/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057599",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057599/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057599/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057600",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057601",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057601/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27057602",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057602/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057602/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057603",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057603/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057603/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057604",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057604/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057604/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057605",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057605/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057605/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057606",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057606/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057606/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057607",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057607/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057607/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057608",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057608/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057608/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057609",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057609/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057609/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057610",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057610/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057610/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057611",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057611/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057611/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057612",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057612/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057612/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057613",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057613/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057613/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057614",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057614/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057614/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057615",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057615/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057615/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057628",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27057630",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057630/thirsty_mclean/thumbnail.png"
+  },
+  {
+    "synid": "syn27393120",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393120/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393120/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393123",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393123/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393123/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393124",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393124/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393124/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393131",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393131/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393131/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393133",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393133/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393138",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393138/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393138/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393156",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393156/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393156/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393178",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393178/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393191",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393191/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393199",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393199/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393199/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393203",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393203/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393203/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393207",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393207/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393207/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393209",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393209/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393209/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393213",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393213/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393213/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393214",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393214/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393214/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393216",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393216/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393216/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393217",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393217/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393217/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393221",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393221/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393221/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393223",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393223/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393234",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393234/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393239",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393239/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393239/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393242",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393242/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393242/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393243",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393243/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393243/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393250",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393250/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393250/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393254",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393254/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393254/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393256",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393256/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393258",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393258/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393258/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393262",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393262/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393262/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393263",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393263/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393263/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393268",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393268/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393268/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393272",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393272/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393272/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393274",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393274/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393274/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393276",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393276/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393276/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393277",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393277/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393277/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393280",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393280/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393280/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393281",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393281/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393284",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393284/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393284/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393285",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393285/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393285/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393290",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393290/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393296",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393296/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393296/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393298",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393298/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393298/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393300",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393300/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393300/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393301",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393301/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393301/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393303",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393303/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393303/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393304",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393304/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393306",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393306/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393760",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393760/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393760/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393761",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393761/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393761/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393764",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393764/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393764/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393767",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393767/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393769",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393769/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393769/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393772",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393772/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393773",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393773/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393773/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393775",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393775/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393775/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393776",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393776/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393776/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393778",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393778/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393778/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393779",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393779/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393779/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393780",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393780/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393780/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393781",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393781/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393781/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393782",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393782/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393782/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393784",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393784/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393784/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393785",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393785/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393785/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393787",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393787/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393787/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393789",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393789/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393789/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393790",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393790/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393792",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393792/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393792/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393793",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393793/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393793/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393794",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393794/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393794/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393795",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393795/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393795/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393796",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393796/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393796/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393797",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393797/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393797/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn27393799",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27393799/sad_poitras_3/thumbnail.jpg"
+  },
+  {
+    "synid": "syn28564179",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564180",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564188",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564193",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564197",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564201",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564202",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564204",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564205",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564208",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564212",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564213",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564216",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564220",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564221",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564226",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564227",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564230",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564232",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564233",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564234",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564239",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564242",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564251",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564253",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564269",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564270",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564275",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564279",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564284",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564301",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564306",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564330",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564350",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564376",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564381",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564393",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564441",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564494",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564516",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564520",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564528",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564538",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564542",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564549",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564552",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564554",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564566",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564569",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564581",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564584",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564585",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564602",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564608",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564611",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564614",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564616",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564621",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564625",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564630",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564644",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564645",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564649",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564658",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564664",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564666",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564671",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564675",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564677",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564693",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564694",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564702",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564703",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564705",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn28564712",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/index.html"
+  },
+  {
+    "synid": "syn25547794",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547794/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547796",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547796/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547797",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547797/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547800",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547800/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547801",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547801/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547802",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547802/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547811",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547811/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547814",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547814/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547821",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547821/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547823",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547823/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547824",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547824/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25547826",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25547826/loving_swartz_2/minerva/Group-12_44__TargetSegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871033",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871033/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871034",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871034/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871035",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871035/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871037",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871037/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871038",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871038/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871039",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871039/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871040",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871040/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871042",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871042/naughty_rubens/minerva/Group-9_32__TargetKi-67--33__TargetLag3--34__TargetLamin-AC--35__TargetMPO/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871043",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871043/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871046",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871046/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871056",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871056/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871070",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871070/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871080",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871080/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871085",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871085/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871086",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871086/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871089",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871089/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871090",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871090/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871091",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871091/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871092",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871092/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871093",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871093/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871096",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871096/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871097",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871097/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871098",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871098/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871099",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871099/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871100",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871100/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871101",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871101/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871114",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871114/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871117",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871117/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871119",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871119/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871121",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871121/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871122",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871122/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871124",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871124/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871125",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871125/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871129",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871129/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871130",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871130/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871133",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871133/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871139",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871139/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871140",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871140/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871143",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871143/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871147",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871147/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn25871148",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn25871148/loving_swartz_2/minerva/Group-12_44__Targetsegmentation--45__TargetTa--46__TargetTbet--47__TargetVimentin/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564179",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564179/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564180",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564180/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564188",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564188/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564193",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564193/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564197",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564197/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564201",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564201/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564202",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564202/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564204",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564204/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564205",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564205/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564208",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564208/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564212",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564212/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564213",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564213/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564216",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564216/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564220",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564220/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564221",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564221/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564226",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564226/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564227",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564227/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564230",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564230/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564232",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564232/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564233",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564233/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564234",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564234/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564239",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564239/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564242",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564242/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564251",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564251/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564253",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564253/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564269",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564269/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564270",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564270/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564275",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564275/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564279",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564279/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564284",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564284/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564301",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564301/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564306",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564306/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564330",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564330/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564350",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564350/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564376",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564376/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564381",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564381/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564393",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564393/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564441",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564441/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564494",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564494/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564516",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564516/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564520",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564520/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564528",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564528/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564538",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564538/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564542",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564542/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564549",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564549/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564552",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564552/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564554",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564554/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564566",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564566/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564569",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564569/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564581",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564581/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564584",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564584/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564585",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564585/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564602",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564602/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564608",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564608/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564611",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564611/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564614",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564614/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564616",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564616/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564621",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564621/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564625",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564625/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564630",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564630/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564644",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564644/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564645",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564645/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564649",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564649/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564658",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564658/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564664",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564664/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564666",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564666/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564671",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564671/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564675",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564675/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564677",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564677/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564693",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564693/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564694",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564694/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564702",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564702/v1/minerva/Group-7_24__Histone-H3--25__DNA--26__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564703",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564703/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564705",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564705/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  },
+  {
+    "synid": "syn28564712",
+    "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/index.html",
+    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn28564712/v1/minerva/Group-7_24__HLA-DR--25__Histone-H3--26__DNA--27__DNA/0_0_0.jpg"
+  }
 ]

--- a/data/htan-imaging-assets.json
+++ b/data/htan-imaging-assets.json
@@ -5394,18 +5394,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27021863/irreverent_hoover/thumbnail.jpg"
   },
   {
-    "synid": "syn27056837",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056837/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056838",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056838/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056839",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056839/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056840",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056840/zen_leavitt_2/thumbnail.jpg"
@@ -5426,14 +5414,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056843/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056844",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056844/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056845",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056845/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056846",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056846/zen_leavitt_2/thumbnail.jpg"
@@ -5444,21 +5424,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056847/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056848",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056848/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056849",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056849/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056850",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056850/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056851",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056851/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056852",
@@ -5471,17 +5439,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056853/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056854",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056854/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056855",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056855/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056856",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056856/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056857",
@@ -5504,25 +5464,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056860/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056861",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056861/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056862",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056862/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056863",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056863/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056864",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056864/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056865",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056865/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056866",
@@ -5540,18 +5484,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056868/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056869",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056869/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056870",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056870/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056875",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056875/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056893",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056893/zen_leavitt_2/thumbnail.jpg"
@@ -5562,17 +5494,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056894/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056895",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056895/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056896",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056896/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056897",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056897/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056908",
@@ -5585,29 +5509,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056912/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056913",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056913/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056914",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056914/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056915",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056915/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056919",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056919/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056920",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056920/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056921",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056921/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056922",
@@ -5620,54 +5524,14 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056923/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056925",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056925/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056926",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056926/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056927",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056927/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056928",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056928/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056929",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056929/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056930",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056930/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056931",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056931/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056932",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056932/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056933",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056933/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056934",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056934/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056935",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056935/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056936",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056936/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056937",
@@ -5685,45 +5549,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056939/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056940",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056940/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056941",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056941/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056942",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056942/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056943",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056943/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056944",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056944/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056945",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056945/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056946",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056946/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056947",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056947/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056948",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056948/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056949",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056949/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056950",
@@ -5736,33 +5564,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056952/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056953",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056953/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056954",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056954/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056955",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056955/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056956",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056956/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056957",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056957/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056958",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056958/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056959",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056959/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056960",
@@ -5775,17 +5579,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056961/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056962",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056962/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056963",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056963/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056964",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056964/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056965",
@@ -5801,14 +5597,6 @@
     "synid": "syn27056967",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056967/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056968",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056968/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056969",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056969/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056970",
@@ -5829,42 +5617,6 @@
     "synid": "syn27056973",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056973/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27056974",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056974/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056975",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056975/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056976",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056976/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056977",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056977/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056978",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056978/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056979",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056979/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056984",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056984/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056985",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056985/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056987",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056987/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27056988",
@@ -5892,30 +5644,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056992/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27056993",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056993/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056994",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056994/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056995",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056995/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056996",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056996/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056997",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056997/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27056998",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056998/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27056999",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27056999/zen_leavitt_2/thumbnail.jpg"
@@ -5931,10 +5659,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057001/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057002",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057002/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057004",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057004/zen_leavitt_2/thumbnail.jpg"
@@ -5945,37 +5669,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057005/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057006",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057006/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057007",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057007/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057008",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057008/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057009",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057009/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057010",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057010/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057011",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057011/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057012",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057012/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057013",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057013/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057014",
@@ -5983,25 +5679,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057014/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057015",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057015/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057016",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057016/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057017",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057017/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057018",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057018/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057019",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057019/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057020",
@@ -6014,14 +5694,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057021/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057022",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057022/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057023",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057023/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057024",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057024/zen_leavitt_2/thumbnail.jpg"
@@ -6032,77 +5704,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057025/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057027",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057027/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057028",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057028/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057029",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057029/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057030",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057030/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057031",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057031/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057032",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057032/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057033",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057033/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057034",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057034/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057035",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057035/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057036",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057036/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057038",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057038/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057039",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057039/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057040",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057040/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057041",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057041/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057042",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057042/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057043",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057043/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057044",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057044/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057045",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057045/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057046",
@@ -6110,49 +5714,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057046/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057047",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057047/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057048",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057048/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057049",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057049/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057050",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057050/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057051",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057051/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057052",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057052/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057053",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057053/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057054",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057054/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057055",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057055/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057056",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057056/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057058",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057058/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057059",
@@ -6160,29 +5724,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057059/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057060",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057060/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057061",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057061/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057062",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057062/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057063",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057063/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057064",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057064/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057065",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057065/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057066",
@@ -6190,58 +5734,14 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057066/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057067",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057067/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057068",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057068/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057069",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057069/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057070",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057070/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057071",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057071/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057072",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057072/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057073",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057073/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057074",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057074/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057075",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057075/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057076",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057076/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057077",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057077/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057078",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057078/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057079",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057079/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057080",
@@ -6254,65 +5754,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057081/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057082",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057082/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057083",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057083/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057084",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057084/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057085",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057085/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057086",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057086/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057087",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057087/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057088",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057088/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057089",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057089/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057090",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057090/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057091",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057091/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057092",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057092/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057093",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057093/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057094",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057094/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057095",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057095/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057096",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057096/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057097",
@@ -6320,61 +5764,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057097/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057098",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057098/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057099",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057099/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057100",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057100/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057101",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057101/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057102",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057102/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057103",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057103/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057104",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057104/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057105",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057105/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057106",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057106/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057107",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057107/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057108",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057108/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057109",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057109/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057110",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057110/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057111",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057111/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057112",
@@ -6387,49 +5779,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057113/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057114",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057114/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057115",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057115/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057118",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057118/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057119",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057119/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057120",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057120/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057121",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057121/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057122",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057122/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057123",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057123/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057124",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057124/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057125",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057125/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057126",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057126/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057127",
@@ -6447,49 +5799,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057129/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057130",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057130/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057131",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057131/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057132",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057132/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057133",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057133/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057134",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057134/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057135",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057135/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057136",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057136/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057137",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057137/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057138",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057138/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057139",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057139/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057140",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057140/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057141",
@@ -6497,89 +5809,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057141/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057142",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057142/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057143",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057143/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057144",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057144/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057145",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057145/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057146",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057146/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057147",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057147/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057149",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057149/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057150",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057150/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057151",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057151/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057152",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057152/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057153",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057153/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057154",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057154/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057155",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057155/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057156",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057156/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057157",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057157/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057158",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057158/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057159",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057159/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057160",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057160/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057161",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057161/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057162",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057162/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057163",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057163/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057164",
@@ -6595,34 +5827,6 @@
     "synid": "syn27057166",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057166/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057167",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057167/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057168",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057168/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057169",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057169/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057170",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057170/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057171",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057171/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057172",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057172/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057173",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057173/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057174",
@@ -6645,50 +5849,14 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057177/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057178",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057178/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057179",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057179/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057180",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057180/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057181",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057181/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057182",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057182/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057183",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057183/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057184",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057184/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057185",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057185/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057186",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057186/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057187",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057187/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057188",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057188/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057189",
@@ -6701,57 +5869,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057190/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057191",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057191/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057192",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057192/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057193",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057193/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057194",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057194/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057195",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057195/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057198",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057198/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057199",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057199/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057200",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057200/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057201",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057201/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057202",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057202/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057203",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057203/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057204",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057204/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057205",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057205/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057206",
@@ -6774,34 +5894,14 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057209/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057210",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057210/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057211",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057211/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057212",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057212/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057213",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057213/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057214",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057214/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057215",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057215/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057216",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057216/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057217",
@@ -6812,10 +5912,6 @@
     "synid": "syn27057218",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057218/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057219",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057219/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057220",
@@ -6833,25 +5929,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057222/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057223",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057223/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057224",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057224/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057225",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057225/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057226",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057226/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057227",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057227/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057228",
@@ -6859,29 +5939,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057228/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057229",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057229/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057230",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057230/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057231",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057231/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057232",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057232/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057233",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057233/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057234",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057234/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057235",
@@ -6892,18 +5952,6 @@
     "synid": "syn27057236",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057236/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057237",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057237/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057238",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057238/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057239",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057239/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057240",
@@ -6921,21 +5969,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057242/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057243",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057243/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057244",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057244/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057245",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057245/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057246",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057246/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057247",
@@ -6951,18 +5987,6 @@
     "synid": "syn27057249",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057249/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057250",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057250/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057251",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057251/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057252",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057252/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057256",
@@ -6990,29 +6014,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057260/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057261",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057261/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057262",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057262/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057263",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057263/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057264",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057264/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057270",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057270/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057273",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057273/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057275",
@@ -7023,10 +6027,6 @@
     "synid": "syn27057281",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057281/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057289",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057289/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057296",
@@ -7052,10 +6052,6 @@
     "synid": "syn27057317",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057317/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057318",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057318/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057322",
@@ -7088,10 +6084,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057328/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057329",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057329/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057330",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057330/zen_leavitt_2/thumbnail.jpg"
@@ -7117,14 +6109,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057334/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057335",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057335/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057336",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057336/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057337",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057337/zen_leavitt_2/thumbnail.jpg"
@@ -7135,17 +6119,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057338/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057339",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057339/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057340",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057340/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057341",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057341/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057342",
@@ -7166,14 +6142,6 @@
     "synid": "syn27057345",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057345/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057346",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057346/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057347",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057347/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057348",
@@ -7226,10 +6194,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057357/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057358",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057358/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057362",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057362/zen_leavitt_2/thumbnail.jpg"
@@ -7263,14 +6227,6 @@
     "synid": "syn27057368",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057368/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057370",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057370/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057371",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057371/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057372",
@@ -7313,10 +6269,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057380/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057381",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057381/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057382",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057382/zen_leavitt_2/thumbnail.jpg"
@@ -7337,10 +6289,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057385/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057386",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057386/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057387",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057387/zen_leavitt_2/thumbnail.jpg"
@@ -7349,10 +6297,6 @@
     "synid": "syn27057388",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057388/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057389",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057389/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057390",
@@ -7383,10 +6327,6 @@
     "synid": "syn27057395",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057395/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057396",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057396/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057397",
@@ -7424,17 +6364,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057403/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057404",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057404/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057405",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057405/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057406",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057406/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057407",
@@ -7470,14 +6402,6 @@
     "synid": "syn27057413",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057413/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057414",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057414/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057415",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057415/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057416",
@@ -7550,10 +6474,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057429/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057430",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057430/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057431",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057431/zen_leavitt_2/thumbnail.jpg"
@@ -7572,10 +6492,6 @@
     "synid": "syn27057434",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057434/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057435",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057435/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057436",
@@ -7608,17 +6524,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057441/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057442",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057442/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057443",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057443/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057444",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057444/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057445",
@@ -7649,10 +6557,6 @@
     "synid": "syn27057450",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057450/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057451",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057451/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057452",
@@ -7688,10 +6592,6 @@
     "synid": "syn27057458",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057458/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057459",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057459/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057460",
@@ -7772,10 +6672,6 @@
     "synid": "syn27057475",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057475/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057476",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057476/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057477",
@@ -7898,10 +6794,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057502/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057503",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057503/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057504",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057504/zen_leavitt_2/thumbnail.jpg"
@@ -7987,10 +6879,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057524/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057525",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057525/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057526",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057526/zen_leavitt_2/thumbnail.jpg"
@@ -8019,10 +6907,6 @@
     "synid": "syn27057531",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057531/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057532",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057532/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057533",
@@ -8090,10 +6974,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057546/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057547",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057547/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057548",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057548/zen_leavitt_2/thumbnail.jpg"
@@ -8159,10 +7039,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057563/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057564",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057564/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057565",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057565/zen_leavitt_2/thumbnail.jpg"
@@ -8223,10 +7099,6 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057577/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057578",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057578/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057579",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057579/zen_leavitt_2/thumbnail.jpg"
@@ -8237,17 +7109,9 @@
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057580/zen_leavitt_2/thumbnail.jpg"
   },
   {
-    "synid": "syn27057581",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057581/thirsty_mclean/thumbnail.png"
-  },
-  {
     "synid": "syn27057582",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057582/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057583",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057583/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057584",
@@ -8258,10 +7122,6 @@
     "synid": "syn27057585",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057585/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057586",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057586/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057587",
@@ -8282,14 +7142,6 @@
     "synid": "syn27057590",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057590/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057591",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057591/thirsty_mclean/thumbnail.png"
-  },
-  {
-    "synid": "syn27057592",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057592/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057593",
@@ -8330,10 +7182,6 @@
     "synid": "syn27057600",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057600/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057601",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057601/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27057602",
@@ -8409,10 +7257,6 @@
     "synid": "syn27057628",
     "minerva": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/minerva/index.html",
     "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057628/zen_leavitt_2/thumbnail.jpg"
-  },
-  {
-    "synid": "syn27057630",
-    "thumbnail": "https://d3p249wtgzkn5u.cloudfront.net/synid/syn27057630/thirsty_mclean/thumbnail.png"
   },
   {
     "synid": "syn27393120",


### PR DESCRIPTION
Were we have a Minerva story but are missing a thumbnail because of an error in Miniature (typically caused by blank or low contrast channels or a poorly formatted image) we can take one of the top level jpeg tiles as a thumbnail.