### PR TITLE
Rename 'Download Source' filter labels to 'Data Access'

### DIFF
--- a/components/FileTable.tsx
+++ b/components/FileTable.tsx
@@ -556,7 +556,7 @@ export default class FileTable extends React.Component<IFileTableProps> {
                 sortable: true,
             },
             {
-                name: 'Download Source',
+                name: 'Data Access',
                 selector: 'downloadSource',
                 wrap: true,
                 sortable: true,

--- a/components/filter/FilterControls.tsx
+++ b/components/filter/FilterControls.tsx
@@ -303,9 +303,9 @@ const FilterControls: React.FunctionComponent<IFilterControlsProps> = observer(
 
                 <div>
                     <div style={{ width: 170 }}>
-                        <FilterPanel placeholder={'Download Source'}>
+                        <FilterPanel placeholder={'Data Access'}>
                             <FilterPropertyColumnShell
-                                title={'Download Source'}
+                                title={'Data Access'}
                             >
                                 <FilterCheckList
                                     setFilter={props.setFilter}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -125,7 +125,7 @@ export const AttributeMap: { [attr in AttributeNames]: IAttributeInfo } = {
     },
     [AttributeNames.downloadSource]: {
         path: 'downloadSource',
-        displayName: 'Download Source',
+        displayName: 'Data Access',
     },
     [AttributeNames.releaseVersion]: {
         path: 'releaseVersion',


### PR DESCRIPTION
Following up from #475 and to fully complete #468, I've taken a shot at renaming the `Download Source` filter to be `Data Access`.

I've left the underlying attribute name as `downloadSource` but updated the relevant `name`, `displayName` and `title` elements that showed up in a full repo search for `Download Source`.