### PR TITLE
change download & metadata buttons

### DIFF
--- a/components/FileTable.tsx
+++ b/components/FileTable.tsx
@@ -57,7 +57,7 @@ interface IFileDownloadModalProps {
     isOpen: boolean;
 }
 
-const DETAILS_COLUMN_NAME = 'Details';
+const DETAILS_COLUMN_NAME = 'Metadata';
 
 const CDSInstructions: React.FunctionComponent<{ files: Entity[] }> = (
     props
@@ -390,6 +390,34 @@ export default class FileTable extends React.Component<IFileTableProps> {
     @observable columnVisibility: { [columnKey: string]: boolean } = {};
     @observable selectedLevels: string[] = this.allLevels;
 
+    getDownloadButton(
+        disabledText: string,
+        style?: React.CSSProperties
+    ): JSX.Element {
+        return (
+            <button
+                className={classNames(
+                    'btn',
+                    this.hasFilesSelected ? 'btn-primary' : 'btn-secondary'
+                )}
+                disabled={!this.hasFilesSelected}
+                onMouseDown={this.onDownload}
+                style={style}
+            >
+                {this.hasFilesSelected ? (
+                    <>
+                        <FontAwesomeIcon icon={faDownload} />{' '}
+                        {`Download ${this.selected.length} selected ${
+                            this.selected.length === 1 ? 'file' : 'files'
+                        }`}
+                    </>
+                ) : (
+                    disabledText
+                )}
+            </button>
+        );
+    }
+
     get defaultColumns(): IEnhancedDataTableColumn<Entity>[] {
         return [
             {
@@ -528,7 +556,7 @@ export default class FileTable extends React.Component<IFileTableProps> {
                                     this.viewDetailsFile = file;
                                 })}
                             >
-                                View Details
+                                View Metadata
                             </a>
                         );
                     }
@@ -964,21 +992,9 @@ export default class FileTable extends React.Component<IFileTableProps> {
                 <EnhancedDataTable
                     columnVisibility={this.columnVisibility}
                     onChangeColumnVisibility={this.setColumnVisibility}
-                    customControls={
-                        <button
-                            className={classNames(
-                                'btn btn-primary',
-                                !this.hasFilesSelected ? 'invisible' : ''
-                            )}
-                            disabled={!this.hasFilesSelected}
-                            onMouseDown={this.onDownload}
-                        >
-                            <FontAwesomeIcon icon={faDownload} />{' '}
-                            {`Download ${this.selected.length} selected ${
-                                this.selected.length === 1 ? 'file' : 'files'
-                            }`}
-                        </button>
-                    }
+                    customControls={this.getDownloadButton(
+                        'Select files to download below'
+                    )}
                     extraControlsInsideDataTableControls={
                         this.props.enableLevelFilter ? (
                             <LevelSelect
@@ -1015,20 +1031,9 @@ export default class FileTable extends React.Component<IFileTableProps> {
                     customStyles={getDefaultDataTableStyle()}
                 />
 
-                <button
-                    style={{ marginTop: -70 }}
-                    className={classNames(
-                        'btn btn-primary',
-                        !this.hasFilesSelected ? 'invisible' : ''
-                    )}
-                    disabled={!this.hasFilesSelected}
-                    onMouseDown={this.onDownload}
-                >
-                    <FontAwesomeIcon icon={faDownload} />{' '}
-                    {this.hasFilesSelected
-                        ? 'Download selected files'
-                        : 'Select files for download below'}
-                </button>
+                {this.getDownloadButton('Select files to download above', {
+                    marginTop: -70,
+                })}
             </>
         ) : null;
     }

--- a/packages/data-portal-table/src/components/DataTableControls.tsx
+++ b/packages/data-portal-table/src/components/DataTableControls.tsx
@@ -38,14 +38,18 @@ export default class DataTableControls extends React.Component<IDataTableControl
                 <Tooltip
                     overlay={
                         <span>
-                            Download the entire table data including the hidden
-                            columns as a TSV file
+                            Download the entire metadata table below as a TSV
+                            file including the hidden columns
                         </span>
                     }
                     placement="left"
                 >
-                    <button className="btn" onClick={this.props.onDownload}>
-                        <FontAwesomeIcon icon={faDownload} />
+                    <button
+                        className="btn btn-light"
+                        onClick={this.props.onDownload}
+                        style={{ marginRight: 10 }}
+                    >
+                        <FontAwesomeIcon icon={faDownload} /> Download Metadata
                     </button>
                 </Tooltip>
                 {this.props.extraControls}


### PR DESCRIPTION
Show button when no files are selected like this (was hidden before):

![image](https://github.com/ncihtan/htan-portal/assets/1334004/1d5b2785-b6ed-4bb2-9b23-107358a989a5)

It wasn't entirely clear to people that "View Details" and the download button would download all the metadata, so make things more explicit with a button like:

![image](https://github.com/ncihtan/htan-portal/assets/1334004/8408faf0-fa2e-4b5b-b061-192e0b6ae6f3)

and change "Details" text to:

<img width="125" alt="image" src="https://github.com/ncihtan/htan-portal/assets/1334004/666ffbf6-9d25-42f6-ae0f-90225e845592">
