### PR TITLE
Update HTAN Help Desk links

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,7 +5,12 @@ const Footer = () => (
     <footer className={'pageFooter'}>
         Human Tumor Atlas Network (HTAN) | National Cancer Institute{' '}
         {new Date().getFullYear()} |{' '}
-        <a href="mailto:htan@googlegroups.com">htan@googlegroups.com</a>
+        <a
+            href="https://sagebionetworks.jira.com/servicedesk/customer/portal/1"
+            target="_blank"
+        >
+            HTAN Help Desk
+        </a>
     </footer>
 );
 

--- a/components/HtanNavbar.tsx
+++ b/components/HtanNavbar.tsx
@@ -88,15 +88,14 @@ export const HtanNavbar: React.FunctionComponent<{}> = () => {
 
         <NavSection text={'Submit Data'}>
             <NavDropdown.Item href="/transfer">Data Transfer</NavDropdown.Item>
-            <Dropdown.Divider />
-            <Nav.Link href="https://sagebionetworks.jira.com/servicedesk/customer/portal/1">
-                Service Desk
-            </Nav.Link>
         </NavSection>,
 
         <NavSection text={'Support'}>
-            <Nav.Link href="mailto:htan@googlegroups.com">
-                htan@googlegroups.com
+            <Nav.Link
+                href="https://sagebionetworks.jira.com/servicedesk/customer/portal/1"
+                target="_blank"
+            >
+                HTAN Help Desk
             </Nav.Link>
         </NavSection>,
 

--- a/components/PublicationTabs.tsx
+++ b/components/PublicationTabs.tsx
@@ -553,7 +553,8 @@ const PublicationTabs: React.FunctionComponent<IPublicationTabsProps> = observer
                                 please contact the corresponding author(s) and
                                 the{' '}
                                 <a
-                                    href="mailto:htan@googlegroups.com"
+                                    href="https://sagebionetworks.jira.com/servicedesk/customer/portal/1"
+                                    target="_blank"
                                     className="alert-link"
                                 >
                                     HTAN DCC


### PR DESCRIPTION
Deprecate use of googlegroups, use Jira HTAN Help Desk link instead 