### PR TITLE
add more coarse filter for organ type on the explore page

### DIFF
--- a/packages/data-portal-commons/src/lib/getCaseValues.ts
+++ b/packages/data-portal-commons/src/lib/getCaseValues.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { Entity } from './entity';
-import { getNormalizedOrgan } from '@htan/data-portal-commons';
+import { getNormalizedOrgan } from './entityReportHelpers';
 
 export function getCaseValues(propName: keyof Entity) {
     return (e: Entity) => {
@@ -12,12 +12,10 @@ export function getCaseValues(propName: keyof Entity) {
     };
 }
 
-export function getNormalizedOrganCaseValues() {
-    return (e: Entity) => {
-        if (e.cases) {
-            return _.uniq(e.cases.map((c) => getNormalizedOrgan(c) as string));
-        } else {
-            return [getNormalizedOrgan(e) as string];
-        }
-    };
+export function getNormalizedOrganCaseValues(e: Entity) {
+    if (e.cases) {
+        return _.uniq(e.cases.map((c) => getNormalizedOrgan(c)));
+    } else {
+        return [getNormalizedOrgan(e)];
+    }
 }

--- a/packages/data-portal-commons/src/lib/types.ts
+++ b/packages/data-portal-commons/src/lib/types.ts
@@ -31,8 +31,8 @@ export const HTANToGenericAttributeMap: {
 export const FileAttributeMap: {
     [attr in AttributeNames]: IAttributeInfo<Entity>;
 } = {
-    [AttributeNames.OrganType]: {
-        getValues: getNormalizedOrganCaseValues(),
+    [AttributeNames.organType]: {
+        getValues: getNormalizedOrganCaseValues,
         displayName: 'Organ',
         caseFilter: true,
     },

--- a/packages/data-portal-commons/src/lib/types.ts
+++ b/packages/data-portal-commons/src/lib/types.ts
@@ -38,7 +38,7 @@ export const FileAttributeMap: {
     },
     [AttributeNames.TissueorOrganofOrigin]: {
         getValues: getCaseValues('TissueorOrganofOrigin'),
-        displayName: 'Organ Details',
+        displayName: 'Organ Detailed',
         caseFilter: true,
     },
     [AttributeNames.PrimaryDiagnosis]: {

--- a/packages/data-portal-explore/src/components/FileFilterControls.tsx
+++ b/packages/data-portal-explore/src/components/FileFilterControls.tsx
@@ -56,7 +56,7 @@ export const FileFilterControls: React.FunctionComponent<IFileFilterControlProps
                 <FilterDropdown
                     {...dropdownProps}
                     attributes={[
-                        AttributeNames.OrganType,
+                        AttributeNames.organType,
                         AttributeNames.TissueorOrganofOrigin,
                     ]}
                     className={styles.filterCheckboxListContainer}

--- a/packages/data-portal-utils/src/lib/types.ts
+++ b/packages/data-portal-utils/src/lib/types.ts
@@ -7,7 +7,6 @@ export interface IAttributeInfo<T> {
 
 export enum AttributeNames {
     // Synapse attribute names
-    OrganType = 'OrganType',
     TissueorOrganofOrigin = 'TissueorOrganofOrigin',
     PrimaryDiagnosis = 'PrimaryDiagnosis',
     Gender = 'Gender',
@@ -22,6 +21,7 @@ export enum AttributeNames {
     FileFormat = 'FileFormat',
 
     // Derived or attached in frontend
+    organType = 'organType',
     assayName = 'assayName',
     downloadSource = 'downloadSource',
     releaseVersion = 'releaseVersion',


### PR DESCRIPTION
Fixing the #595 issue:
1. Created a filter by Organ Type filter on the organ dropdown box on the explore page.
2. Changed the original 'Organ' label in the dropdown box to the 'Organ Details'.