### PR TITLE
Workaround for dynamic publication pages

### DIFF
--- a/data/processSynapseJSON.ts
+++ b/data/processSynapseJSON.ts
@@ -108,6 +108,12 @@ async function writeProcessedFile() {
         'public/processed_syn_data.json',
         JSON.stringify(processed)
     );
+
+    // create a separate file to store static publication page ids
+    fs.writeFileSync(
+        'pages/publications/static_page_ids.json',
+        JSON.stringify(_.keys(processed.publicationManifestByUid), null, 2)
+    );
 }
 
 function getSynData(): SynapseData {

--- a/packages/data-portal-commons/src/lib/publicationHelpers.ts
+++ b/packages/data-portal-commons/src/lib/publicationHelpers.ts
@@ -233,3 +233,7 @@ export async function fetchPublicationSummaries(
 
     return undefined;
 }
+
+export function getAllPublicationPagePaths(ids: string[]) {
+    return ids.map((id) => ({ params: { id } }));
+}

--- a/pages/publications/[id].tsx
+++ b/pages/publications/[id].tsx
@@ -16,6 +16,7 @@ import {
     Entity,
     fillInEntities,
     filterFiles,
+    getAllPublicationPagePaths,
     getFilteredCases,
     getPublicationAuthors,
     getPublicationDOI,
@@ -40,6 +41,8 @@ import {
     SchemaDataById,
 } from '@htan/data-portal-schema';
 import { GenericAttributeNames } from '@htan/data-portal-utils';
+
+import publicationIds from './static_page_ids.json';
 
 const filterByAttrName = (filters: SelectedFilter[]) => {
     return _.chain(filters)
@@ -288,8 +291,10 @@ export const getStaticProps: GetStaticProps = async (context) => {
 
 export async function getStaticPaths() {
     return {
-        paths: [], // indicates that no page needs be created at build time
-        // fallback: false,
-        fallback: 'blocking', // page will wait for the HTML to be generated
+        paths: getAllPublicationPagePaths(publicationIds), // indicates that no page needs be created at build time
+        fallback: false,
+        // TODO disabling dynamic pages for now
+        // paths: [], // indicates that no page needs be created at build time
+        // fallback: 'blocking', // page will wait for the HTML to be generated
     };
 }

--- a/pages/publications/static_page_ids.json
+++ b/pages/publications/static_page_ids.json
@@ -1,0 +1,21 @@
+[
+  "hta1_2024_biorxiv_anand-g-patel",
+  "hta11_2021_cell_bob-chen",
+  "hta11_2023_cell_cody-n-heiser",
+  "hta11_2023_biorxiv_mirazul-islam",
+  "hta9_2023_biorxiv_allison-l-creason",
+  "hta9_2022_cell-reports-medicine_brett-e-johnson",
+  "hta7_2022_cell_jia-ren-lin",
+  "hta7_2022_cancer-discovery_ajit-j-nirmal",
+  "hta7_2023_biorxiv_clarence-yapp",
+  "hta3_2023_cancer-research_jane-yanagawa",
+  "hta12_2023_nature_nadezhda-v-terekhanova",
+  "hta12_2023_nature-communications_yige-wu",
+  "hta12_2022_nature-genetics_daniel-cui-zhou",
+  "hta4_2022_blood_changya-chen",
+  "hta8_2021_cancer-cell_joseph-m-chan",
+  "hta8_2023_nature-immunology_ariella-glasner",
+  "hta6_2022_cell_tyler-risom",
+  "hta6_2022_cancer-cell_siri-h-strand",
+  "hta10_2022_nature-genetics_winston-r-becker"
+]


### PR DESCRIPTION
Generate publication IDs as part of processedSynapseJSON. This hopefully fixes 5x errors in production