### PR TITLE
Exclude therapy and therapy ids from file table columns

### DIFF
--- a/packages/data-portal-explore/src/components/FileTable.tsx
+++ b/packages/data-portal-explore/src/components/FileTable.tsx
@@ -897,6 +897,7 @@ export class FileTable extends React.Component<IFileTableProps> {
             downloadSource: true,
             viewers: true,
             imageChannelMetadata: true,
+            therapy: true,
 
             //others to exclude
             Component: true,
@@ -906,6 +907,7 @@ export class FileTable extends React.Component<IFileTableProps> {
             demographics: true,
             demographicsIds: true,
             diagnosisIds: true,
+            therapyIds: true,
         };
 
         const listSelectors: any = {


### PR DESCRIPTION
Fix #648