### PR TITLE
Workaround to remove a metadata file

### DIFF
--- a/data/syn_metadata.json
+++ b/data/syn_metadata.json
@@ -521,11 +521,6 @@
             "numItems": 2
         },
         {
-            "component": "FollowUp",
-            "synapseId": "syn42296194",
-            "numItems": 2
-        },
-        {
             "component": "Therapy",
             "synapseId": "syn42296367",
             "numItems": 2


### PR DESCRIPTION
This is a quick workaround to remove a metadata file from the list.

We have to fix this on the synapse side because the file will come back when rerun the python importer script.