### PR TITLE
Add HTAPP publication redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,11 @@ module.exports = withMDX({
                 destination: '/authors',
                 permanent: true,
             },
+            {
+                source: '/publications/htapp_mbc_klughammer_2024',
+                destination: '/',
+                permanent: false,
+            },
         ];
     },
 });


### PR DESCRIPTION
This is a temporary redirect, which can be removed once the publication page is working