### PR TITLE
Use coarse organ type when counting organs in the explore summary header

### DIFF
--- a/packages/data-portal-explore/src/lib/helpers.ts
+++ b/packages/data-portal-explore/src/lib/helpers.ts
@@ -17,7 +17,7 @@ export function getDefaultSummaryData<T>(
         },
         {
             displayName: 'Organ',
-            attributeName: AttributeNames.TissueorOrganofOrigin,
+            attributeName: AttributeNames.organType,
         },
         {
             displayName: 'Cancer Type',


### PR DESCRIPTION
Fix #663

![image](https://github.com/user-attachments/assets/b9e5f6d6-63ce-42f7-9195-9af7cebc42b0)

The organ count on the explore page is 22 as opposed to 21 shown on the home page because we filter out `Not Reported` (and `unknown`) there. We can do the same thing for explore page with some additional logic.