### PR TITLE
Add metadata to CGC file download manifest file

### DIFF
--- a/packages/data-portal-explore/src/components/FileTable.tsx
+++ b/packages/data-portal-explore/src/components/FileTable.tsx
@@ -53,11 +53,31 @@ interface IFileDownloadModalProps {
 const DETAILS_COLUMN_NAME = 'Metadata';
 
 function generateCdsManifestFile(files: Entity[]): string | undefined {
-    const columns = ['drs_uri', 'name'];
+    const columns = [
+        'drs_uri',
+        'name',
+        'atlas_name',
+        'biospecimen',
+        'assay_name',
+        'level',
+        'data_file_id',
+        'parent_biospecimen_id',
+        'parent_data_file_id',
+    ];
     const data = _(files)
-        .map((f) => f.viewers?.cds)
-        .compact()
-        .map((asset) => [asset.drs_uri, asset.name])
+        .filter((f) => !!f.viewers?.cds)
+        .map((f) => [
+            f.viewers?.cds?.drs_uri,
+            f.viewers?.cds?.name,
+            f.atlas_name,
+            _.uniq(f.biospecimen.map((b) => b.BiospecimenID)).join(' '),
+            f.assayName,
+            f.level,
+            // make sure to replace all possible commas since we are generating a CSV file
+            f.DataFileID?.replace(/,/g, ' ').trim(),
+            f.ParentBiospecimenID?.replace(/,/g, ' ').trim(),
+            f.ParentDataFileID?.replace(/,/g, ' ').trim(),
+        ])
         .value();
 
     if (data.length > 0) {


### PR DESCRIPTION
Fix #688

Only added the below columns as metadata for now. We can add more columns if needed.

atlas_name, biospecimen, assay_name, level, data_file_id, parent_biospecimen_id, and parent_data_file_id.

When following [this import flow](https://docs.cancergenomicscloud.org/docs/import-from-a-drs-server#import-from-a-manifest-file) in [CGC](https://www.cancergenomicscloud.org/), the extra metadata will show up like:

![image](https://github.com/user-attachments/assets/11fcd0d7-ef2e-492f-a4b0-f714ab352753)
