### PR TITLE
Add minimal padding for publication titles

### DIFF
--- a/packages/data-portal-explore/src/components/PublicationTable.tsx
+++ b/packages/data-portal-explore/src/components/PublicationTable.tsx
@@ -131,6 +131,7 @@ export const PublicationTable: React.FunctionComponent<IPublicationTableProps> =
                     href={`//${
                         window.location.host
                     }/publications/${getPublicationUid(manifest)}`}
+                    className="py-1"
                 >
                     {getPublicationTitle(getSummary(manifest), manifest)}
                 </a>


### PR DESCRIPTION
Fix #760

Before:
![image](https://github.com/user-attachments/assets/1963b9c8-0599-42e1-b29a-197892313fa5)

After:
![image](https://github.com/user-attachments/assets/ab47eedd-1491-4a48-b9bb-45bba010ce36)
