### PR TITLE
Order publication icons by date in atlas table

### DIFF
--- a/packages/data-portal-explore/src/components/AtlasTable.tsx
+++ b/packages/data-portal-explore/src/components/AtlasTable.tsx
@@ -208,9 +208,12 @@ export class AtlasTable extends React.Component<IAtlasTableProps> {
     };
 
     getPublicationManifests = (atlas: Atlas) => {
-        return this.props.publications.filter(
-            (p) => !isManuscriptInReview(p) && p.atlasid === atlas.htan_id
-        );
+        return _(this.props.publications)
+            .filter(
+                (p) => !isManuscriptInReview(p) && p.atlasid === atlas.htan_id
+            )
+            .sortBy([(p) => p.YearofPublication, (p) => p.PMID])
+            .value();
     };
 
     getViewerCounts = (atlas: Atlas) => {


### PR DESCRIPTION
Fix #792

![image](https://github.com/user-attachments/assets/bdf41da6-ecb3-47df-872b-1581627ec84c)
