### PR TITLE
Make sure the entire filename is visible in the tooltip

### DIFF
--- a/packages/data-portal-explore/src/components/FileTable.tsx
+++ b/packages/data-portal-explore/src/components/FileTable.tsx
@@ -238,13 +238,21 @@ const gen3ManifestInstructions = (gen3manifestFile: string | undefined) => {
                     <ol>
                         <li>
                             Install the{' '}
-                            <a href="https://gen3.org/resources/user/gen3-client/#1-installation-instructions" target="_blank" rel="noopener noreferrer">
+                            <a
+                                href="https://gen3.org/resources/user/gen3-client/#1-installation-instructions"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
                                 Gen3 Client
                             </a>
                         </li>
                         <li>
                             Get your{' '}
-                            <a href="https://nci-crdc.datacommons.io/identity" target="_blank" rel="noopener noreferrer">
+                            <a
+                                href="https://nci-crdc.datacommons.io/identity"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
                                 NCI Data Commons Framework Services API Key
                             </a>
                         </li>
@@ -260,7 +268,8 @@ const gen3ManifestInstructions = (gen3manifestFile: string | undefined) => {
                             </pre>
                         </li>
                     </ol>
-                </>.
+                </>
+                .
                 <button
                     className="btn btn-light"
                     onClick={() =>
@@ -721,7 +730,13 @@ export class FileTable extends React.Component<IFileTableProps> {
                         );
 
                     return (
-                        <Tooltip overlay={getFileBase(file.Filename)}>
+                        <Tooltip
+                            overlay={
+                                <span className={styles.filenameTooltipContent}>
+                                    {getFileBase(file.Filename)}
+                                </span>
+                            }
+                        >
                             {linkOut}
                         </Tooltip>
                     );

--- a/packages/data-portal-explore/src/components/fileTable.module.scss
+++ b/packages/data-portal-explore/src/components/fileTable.module.scss
@@ -12,3 +12,7 @@
     /*border: 1px solid #999;*/
     width: 150px;
 }
+
+.filenameTooltipContent {
+    word-break: break-word;
+}


### PR DESCRIPTION
Related to #783

BEFORE:
(File table)
![image](https://github.com/user-attachments/assets/323bc443-2e78-407a-a18f-0187936c572b)

(Metadata details)
![image](https://github.com/user-attachments/assets/ed2dffdc-f84d-4d5c-b34b-c375cdf72eaf)

AFTER:
(File table)
![image](https://github.com/user-attachments/assets/0f988ff7-021f-48e8-8745-c291992bf172)

(Metadata details)
![image](https://github.com/user-attachments/assets/1e8ec5f7-f84c-47cf-8229-252caa973ba8)
