### PR TITLE
Add download source handling for CODEX Level 1 files

### DIFF
--- a/data/processSynapseJSON.ts
+++ b/data/processSynapseJSON.ts
@@ -392,7 +392,10 @@ function addDownloadSourcesInfo(
         }
     } else {
         file.isRawSequencing = false;
-        if (file.synapseId && dbgapImgSynapseSet.has(file.synapseId)) {
+        // Explicitly set CODEX Level 1 files to use Synapse as download source
+        if (file.assayName?.toLowerCase() === 'codex' && file.level === 'Level 1') {
+            file.downloadSource = DownloadSourceCategory.synapse;
+        } else if (file.synapseId && dbgapImgSynapseSet.has(file.synapseId)) {
             // Level 2 imaging data is open access
             // ImagingLevel2, SRRSImagingLevel2 as specified in released.entities table (CDS_Release) column
             if (file.viewers?.cds?.drs_uri) {


### PR DESCRIPTION
Discussed with @inodb that we do need a better way to do this (and we have a plan about making a table of public synapse entities avaliable), but to unblock Stanford, I do wish to make this one more addition at this stage. It will require re-run of the relevent synapse json processing.