### PR TITLE
Update message for unavailable image viewer

### DIFF
--- a/packages/data-portal-explore/src/components/FileTable.tsx
+++ b/packages/data-portal-explore/src/components/FileTable.tsx
@@ -1056,7 +1056,7 @@ export class FileTable extends React.Component<IFileTableProps> {
                     if (cellViewers.length > 0) {
                         return cellViewers;
                     } else if (file.Component.startsWith('ImagingLevel2')) {
-                        return 'Image Viewer Coming Soon';
+                        return 'Image Viewer Not Avaliable';
                     } else {
                         return '';
                     }


### PR DESCRIPTION
This pull request makes a minor update to the `FileTable` component to improve the messaging shown when an image viewer is not available.

- Updated the fallback message for files with a `Component` starting with `ImagingLevel2` from "Image Viewer Coming Soon" to "Image Viewer Not Avaliable" in `FileTable.tsx`.

Closes #843 