### PR TITLE
fix: URL filters not applied when navigating to explore page

### DIFF
--- a/packages/data-portal-explore/src/components/Explore.tsx
+++ b/packages/data-portal-explore/src/components/Explore.tsx
@@ -1,7 +1,7 @@
 'use client';
 import _, { Dictionary } from 'lodash';
 import remoteData, { MobxPromise } from 'mobxpromise';
-import { action, makeObservable, observable, toJS } from 'mobx';
+import { action, makeObservable, observable, runInAction, toJS } from 'mobx';
 import { observer } from 'mobx-react';
 import { ScaleLoader } from 'react-spinners';
 import React from 'react';
@@ -99,6 +99,32 @@ export class Explore extends React.Component<IExploreProps> {
     constructor(props: any) {
         super(props);
         makeObservable(this);
+    }
+
+    componentDidUpdate(prevProps: IExploreProps) {
+        // Sync filters from URL when router becomes ready (Next.js hydration)
+        const newFilters = this.props.getSelectedFilters?.() || [];
+        const prevFilters = prevProps.getSelectedFilters?.() || [];
+
+        // Only update if filters actually changed and we have new filters from URL
+        if (
+            newFilters.length > 0 &&
+            this._selectedFilters.length === 0 &&
+            JSON.stringify(newFilters) !== JSON.stringify(prevFilters)
+        ) {
+            runInAction(() => {
+                this._selectedFilters = newFilters;
+            });
+        }
+
+        // Sync tab from URL when router becomes ready
+        const newTab = this.props.getTab?.();
+        const prevTab = prevProps.getTab?.();
+        if (newTab && newTab !== prevTab && this.currentTab !== newTab) {
+            runInAction(() => {
+                this.currentTab = newTab;
+            });
+        }
     }
 
     unfilteredOptions = new remoteData({


### PR DESCRIPTION
## Summary
Fixes #865 - AutoMinerva images (and other filtered views) not working when clicking links from the atlas table.

## Problem
When clicking on viewer count links (e.g., AutoMinerva count for CHOP), a new tab opens with URL params like:
```
/explore?selectedFilters=[{"group":"viewersArr","value":"autoMinerva"},{"group":"AtlasName","value":"HTAN CHOP"}]&tab=file
```

However, the filters weren't being applied - the page showed the same unfiltered view as the original explore page.

## Root Cause
The `Explore` component's `_selectedFilters` and `currentTab` observables are only initialized once at class instantiation:

```typescript
@observable private _selectedFilters: SelectedFilter[] =
    this.props.getSelectedFilters?.() || [];
@observable private currentTab: ExploreTab =
    this.props.getTab?.() || ExploreTab.ATLAS;
```

With Next.js dynamic routing, `router.query` is empty on the first render before hydration. So when the component initializes, `getSelectedFilters()` returns `[]`, and the filters never update when the router becomes ready.

## Solution
Added `componentDidUpdate` lifecycle method to sync `selectedFilters` and `currentTab` from props when the router becomes ready (i.e., when the URL params are populated after hydration).