### PR TITLE
Add date info to the publication page

### DIFF
--- a/pages/publications/[id].tsx
+++ b/pages/publications/[id].tsx
@@ -16,6 +16,7 @@ import {
     Entity,
     getAllPublicationPagePaths,
     getPublicationAuthors,
+    getPublicationDate,
     getPublicationDOI,
     getPublicationJournal,
     getPublicationPubMedID,
@@ -199,6 +200,12 @@ const PublicationPage = (props: PublicationPageProps) => {
                                             <a href={`https://doi.org/${doi}`}>
                                                 {doi}
                                             </a>
+                                        </>
+                                    )}
+                                    {!isManuscriptInReview(publication) && (
+                                        <>
+                                            &nbsp; Date:{' '}
+                                            {getPublicationDate(publication)}
                                         </>
                                     )}
                                     <br />


### PR DESCRIPTION
Example date display when only year available: https://deploy-preview-870--htan-portal.netlify.app/publications/hta8_2025_biorxiv_alejandro-jim%C3%A9nez-s%C3%A1nchez

<img width="755" height="140" alt="Screenshot 2026-03-03 at 3 48 49 PM" src="https://github.com/user-attachments/assets/cb9d9e13-b4e8-4518-adc3-bc4895a31e1a" />

Example date display with month and day info: https://deploy-preview-870--htan-portal.netlify.app/publications/hta1_2021_cell_karin-pelka

<img width="572" height="174" alt="Screenshot 2026-03-03 at 3 49 46 PM" src="https://github.com/user-attachments/assets/33f2636b-b642-479b-9611-38f044761384" />
