### PR TITLE
Add redirect for Sussman Cell Reports Medicine 2026 publication

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -27,6 +27,12 @@ module.exports = withMDX({
                 destination: '/publications/hta8_2024_nature_a-r-moorman',
                 permanent: false,
             },
+            {
+                source: '/publications/hta4_2026_cell-reports-medicine_jonathan-h-sussman',
+                destination:
+                    '/publications/hta4_2024_biorxiv_jonathan-h-sussman',
+                permanent: false,
+            },
             // phase 1 centers
             ...[...Array(12).keys()].map((i) => ({
                 source: `/hta${i + 1}`,


### PR DESCRIPTION
Adds a redirect so the new publication URL points to the existing biorxiv page.

**Redirect:**
`/publications/hta4_2026_cell-reports-medicine_jonathan-h-sussman` → `/publications/hta4_2024_biorxiv_jonathan-h-sussman`

This allows sharing the new URL now; the redirect can be reversed when the publication page is updated:

https://htan-portal-nextjs-git-fork-snippy-ai-fix-publication-url-htan.vercel.app/publications/hta4_2026_cell-reports-medicine_jonathan-h-sussman