### PR TITLE
Fix files wrongly shown as "coming soon" when they are in CRDC

### DIFF
--- a/packages/data-portal-commons/src/lib/fileHelpers.ts
+++ b/packages/data-portal-commons/src/lib/fileHelpers.ts
@@ -29,6 +29,16 @@ const AUTOMINERVA_MAPPINGS: {
     [synapseId: string]: AutoMinerva;
 } = _.keyBy<AutoMinerva>(AUTOMINERVA_ASSETS, 'synid');
 
+// Pure lookup for a file's CRDC-GC asset. Unlike reading `file.viewers?.crdcGc`,
+// this does not depend on addViewers() having already mutated the file, so it is
+// safe to use for download availability regardless of render/pagination state.
+export function getCrdcGcAsset(
+    file: BaseSerializableEntity,
+    crdcGcMappings: { [fileId: string]: CrdcGcAsset } = CRDCGC_MAPPINGS
+): CrdcGcAsset | undefined {
+    return crdcGcMappings[file.DataFileID];
+}
+
 export function addViewers(
     file: BaseSerializableEntity,
     ucscXenaMappings: { [fileId: string]: string } = UCSCXENA_MAPPINGS,

--- a/packages/data-portal-explore/src/components/FileTable.tsx
+++ b/packages/data-portal-explore/src/components/FileTable.tsx
@@ -42,6 +42,7 @@ import {
     addViewers,
     commonStyles,
     DownloadSourceCategory,
+    getCrdcGcAsset,
     Entity,
     FileAttributeMap,
     getViewerValues,
@@ -95,10 +96,10 @@ function generateCrdcGcManifestFile(files: Entity[]): string | undefined {
         'parent_data_file_id',
     ];
     const data = _(files)
-        .filter((f) => !!f.viewers?.crdcGc)
+        .filter((f) => !!getCrdcGcAsset(f))
         .map((f) => [
-            getDrsUri(f.viewers?.crdcGc?.drs_uri, false, true),
-            f.viewers?.crdcGc?.name,
+            getDrsUri(getCrdcGcAsset(f)?.drs_uri, false, true),
+            getCrdcGcAsset(f)?.name,
             f.atlas_name,
             _.uniq(f.biospecimenIds).join(' '),
             f.assayName,
@@ -119,9 +120,9 @@ function generateCrdcGcManifestFile(files: Entity[]): string | undefined {
 
 function generateGen3ManifestFile(files: Entity[]): string | undefined {
     const data = _(files)
-        .filter((f) => !!f.viewers?.crdcGc)
+        .filter((f) => !!getCrdcGcAsset(f))
         .map((f) => ({
-            object_id: getDrsUri(f.viewers?.crdcGc?.drs_uri, true),
+            object_id: getDrsUri(getCrdcGcAsset(f)?.drs_uri, true),
         }))
         .value();
 
@@ -511,7 +512,7 @@ const SynapseInstructions: React.FunctionComponent<{ files: Entity[] }> = (
 const FileDownloadModal: React.FunctionComponent<IFileDownloadModalProps> = (
     props
 ) => {
-    const crdcGcFiles = props.files.filter((f) => f.viewers?.crdcGc);
+    const crdcGcFiles = props.files.filter((f) => !!getCrdcGcAsset(f));
     const synapseFiles = props.files.filter(
         (f) => f.downloadSource === DownloadSourceCategory.synapse
     );
@@ -520,7 +521,7 @@ const FileDownloadModal: React.FunctionComponent<IFileDownloadModalProps> = (
             f.downloadSource?.includes(DownloadSourceCategory.comingSoon) ||
             (f.Component.startsWith('Imaging') &&
                 (f.level === 'Level 1' || f.level == 'Level 2') &&
-                !f.viewers?.crdcGc)
+                !getCrdcGcAsset(f))
     );
 
     const availabilityMessage = () => {


### PR DESCRIPTION
Fixes #908.

The logic that decides whether each file is available through CRDC or merely "coming soon" was tied into the display logic, exactly as the issue describes.

The download modal categorizes each file by reading `file.viewers?.crdcGc`. That field is only populated as a side effect of `addViewers(file)`, which is called from inside the "View" column's cell renderer in `FileTable.tsx`. react-data-table only renders cells for the rows currently on screen (default 50 per page), so a file only learns that it is in CRDC once its row has actually been rendered. Any file the user has not yet paged or sorted into view still has `viewers.crdcGc` unset, and the modal falls through to the imaging Level 1/2 "coming soon" branch and mislabels it.

This accounts for everything in the report: Level 3 files always showed correctly because their Synapse status is set at ingestion rather than at render time; the Level 2 files flipped to "Available through NCI CRDC" in chunks of ~50 as you sorted because that is one rendered page; and raising "Rows per page" to 500 mostly hid the problem because more rows got rendered. The modal does receive the full selection (the "601 selected files" count is correct) -- the CRDC data just had not been attached to most of those files yet.

## Change

- Add a pure `getCrdcGcAsset(file)` helper in `fileHelpers.ts` that looks the file up in the CRDC/DRS mapping directly, with no mutation and no dependency on whether the row has been rendered.
- Use `getCrdcGcAsset(f)` for the modal's availability categories and for both manifest generators (`crdc_gc_manifest.csv`, `gen3_manifest.json`) instead of the render-populated `viewers.crdcGc` field.
- Leave `addViewers` in the "View" cell, where it is still needed to render the per-row viewer links.

Availability is now derived from the mapping at the moment it is needed, so it no longer depends on pagination, sort order, or rows-per-page.