### PR TITLE
Improve metadata modal content rendering

### DIFF
--- a/packages/data-portal-commons/src/components/ViewDetailsModal.tsx
+++ b/packages/data-portal-commons/src/components/ViewDetailsModal.tsx
@@ -20,8 +20,9 @@ interface IViewDetailsModalProps<CellData> {
         [columnKey: string]: boolean;
     }) => void;
     customContent?: JSX.Element;
-    additionalFields?: { [key: string]: any };
+    additionalColumns?: IEnhancedDataTableColumn<CellData>[];
     disabledAddColumns?: string[];
+    isLoadingAdditionalData?: boolean;
 }
 
 interface IAddColumnIconProps {
@@ -77,7 +78,7 @@ function isEmptyCellValue(value: any): boolean {
     }
 
     if (React.isValidElement(value)) {
-        return isEmptyCellValue((value as any).props?.children);
+        return false;
     }
 
     if (typeof value === 'object') {
@@ -88,16 +89,8 @@ function isEmptyCellValue(value: any): boolean {
 }
 
 const AddColumnIcon: React.FunctionComponent<IAddColumnIconProps> = (props) => {
-    return !props.columnVisibility[props.columnName] ? (
-        <Tooltip
-            overlay={
-                <span>
-                    {props.isDisabled
-                        ? 'Cannot add fetched metadata columns to table'
-                        : 'Add this column to the table'}
-                </span>
-            }
-        >
+    return !props.columnVisibility[props.columnName] && !props.isDisabled ? (
+        <Tooltip overlay={<span>Add this column to the table</span>}>
             <span
                 style={{
                     color: props.isDisabled ? '#ccc' : 'green',
@@ -137,85 +130,62 @@ export const ViewDetailsModal = <CellData extends object>(
             </Modal.Header>
 
             <Modal.Body>
-                <table className="table table-bordered">
-                    <colgroup>
-                        <col style={{ width: '20%' }} />
-                        <col style={{ width: '80%' }} />
-                    </colgroup>
-                    <tbody>
-                        {props.columns.reduce((rows, column) => {
-                            const rawColumnName = column.name as string;
-                            if (EXCLUDED_METADATA_FIELDS.has(rawColumnName)) {
-                                return rows;
-                            }
-                            const cell = renderCell(column, props.cellData!);
-                            if (!isEmptyCellValue(cell)) {
-                                rows.push(
-                                    <tr key={rawColumnName}>
-                                        <td>
-                                            {formatMetadataFieldName(
-                                                rawColumnName,
-                                                METADATA_FIELD_NAME_OVERRIDES
-                                            )}
-                                            {props.columnVisibility &&
-                                                props.onChangeColumnVisibility && (
-                                                    <AddColumnIcon
-                                                        columnVisibility={
-                                                            props.columnVisibility
-                                                        }
-                                                        columnName={
-                                                            rawColumnName
-                                                        }
-                                                        onChangeColumnVisibility={
-                                                            props.onChangeColumnVisibility
-                                                        }
-                                                        isDisabled={props.disabledAddColumns?.includes(
-                                                            rawColumnName
-                                                        )}
-                                                    />
-                                                )}
-                                        </td>
-                                        <td>{cell}</td>
-                                    </tr>
-                                );
-                            }
-                            return rows;
-                        }, [] as any[])}
-                        {props.additionalFields &&
-                            Object.entries(props.additionalFields).map(
-                                ([fieldName, fieldValue]) => {
-                                    if (
-                                        EXCLUDED_METADATA_FIELDS.has(fieldName)
-                                    ) {
-                                        return null;
-                                    }
-                                    if (!isEmptyCellValue(fieldValue)) {
-                                        return (
-                                            <tr key={`additional-${fieldName}`}>
-                                                <td>
-                                                    {formatMetadataFieldName(
-                                                        fieldName,
-                                                        METADATA_FIELD_NAME_OVERRIDES
-                                                    )}
-                                                </td>
-                                                <td>
-                                                    {Array.isArray(fieldValue)
-                                                        ? fieldValue.join(', ')
-                                                        : typeof fieldValue ===
-                                                          'object'
-                                                        ? JSON.stringify(
-                                                              fieldValue
-                                                          )
-                                                        : String(fieldValue)}
-                                                </td>
-                                            </tr>
-                                        );
-                                    }
-                                    return null;
+                {!props.isLoadingAdditionalData && (
+                    <table className="table table-bordered">
+                        <colgroup>
+                            <col style={{ width: '20%' }} />
+                            <col style={{ width: '80%' }} />
+                        </colgroup>
+                        <tbody>
+                            {[
+                                ...props.columns,
+                                ...(props.additionalColumns || []),
+                            ].reduce((rows, column) => {
+                                const rawColumnName = column.name as string;
+                                if (
+                                    EXCLUDED_METADATA_FIELDS.has(rawColumnName)
+                                ) {
+                                    return rows;
                                 }
-                            )}
-                    </tbody>
-                </table>
+                                const cell = renderCell(
+                                    column,
+                                    props.cellData!
+                                );
+                                if (!isEmptyCellValue(cell)) {
+                                    rows.push(
+                                        <tr key={rawColumnName}>
+                                            <td>
+                                                {formatMetadataFieldName(
+                                                    rawColumnName,
+                                                    METADATA_FIELD_NAME_OVERRIDES
+                                                )}
+                                                {props.columnVisibility &&
+                                                    props.onChangeColumnVisibility && (
+                                                        <AddColumnIcon
+                                                            columnVisibility={
+                                                                props.columnVisibility
+                                                            }
+                                                            columnName={
+                                                                rawColumnName
+                                                            }
+                                                            onChangeColumnVisibility={
+                                                                props.onChangeColumnVisibility
+                                                            }
+                                                            isDisabled={props.disabledAddColumns?.includes(
+                                                                rawColumnName
+                                                            )}
+                                                        />
+                                                    )}
+                                            </td>
+                                            <td>{cell}</td>
+                                        </tr>
+                                    );
+                                }
+                                return rows;
+                            }, [] as any[])}
+                        </tbody>
+                    </table>
+                )}
                 {props.customContent}
             </Modal.Body>
 

--- a/packages/data-portal-explore/src/components/FileTable.tsx
+++ b/packages/data-portal-explore/src/components/FileTable.tsx
@@ -4,6 +4,7 @@ import { action, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import React, { CSSProperties } from 'react';
 import { Button, Modal } from 'react-bootstrap';
+import { ScaleLoader } from 'react-spinners';
 import Tooltip from 'rc-tooltip';
 import _ from 'lodash';
 import classNames from 'classnames';
@@ -599,11 +600,30 @@ const CellViewerLink: React.FunctionComponent<{
     const style = props.style || { paddingRight: 5 };
 
     return (
-        <a href={props.url} target="_blank" style={style}>
+        <a
+            href={props.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={style}
+        >
             {props.name} <FontAwesomeIcon icon={faExternalLinkAlt} />
         </a>
     );
 };
+
+function getChannelMetadataUrl(imageChannelMetadata?: {
+    synapseId: string;
+    version: number;
+}): string | null {
+    if (
+        !imageChannelMetadata ||
+        !imageChannelMetadata.synapseId ||
+        !imageChannelMetadata.version
+    ) {
+        return null;
+    }
+    return `https://www.synapse.org/#!Synapse:${imageChannelMetadata.synapseId}.${imageChannelMetadata.version}`;
+}
 
 type ImageViewerInfo = {
     minervaUrl?: string;
@@ -1009,7 +1029,11 @@ export class FileTable extends React.Component<IFileTableProps> {
                                                     >
                                                         <CellViewerLink
                                                             name="Download Channel Metadata"
-                                                            url={`https://www.synapse.org/#!Synapse:${file.imageChannelMetadata.synapseId}.${file.imageChannelMetadata.version}`}
+                                                            url={
+                                                                getChannelMetadataUrl(
+                                                                    file.imageChannelMetadata
+                                                                ) || ''
+                                                            }
                                                             style={{
                                                                 color: 'white',
                                                             }}
@@ -1067,7 +1091,7 @@ export class FileTable extends React.Component<IFileTableProps> {
                     if (cellViewers.length > 0) {
                         return cellViewers;
                     } else if (file.Component.startsWith('ImagingLevel2')) {
-                        return 'Image Viewer Not Avaliable';
+                        return 'Image Viewer Not Available';
                     } else {
                         return '';
                     }
@@ -1270,7 +1294,7 @@ export class FileTable extends React.Component<IFileTableProps> {
         return this.selected.length > 0;
     }
 
-    private getAdditionalFields(): { [key: string]: any } {
+    get additionalFields(): { [key: string]: any } {
         if (
             !this.viewDetailsFile ||
             !this.viewDetailsFileMetadata?.isComplete ||
@@ -1310,12 +1334,52 @@ export class FileTable extends React.Component<IFileTableProps> {
         );
     }
 
+    get metadataColumnsFromFields(): IEnhancedDataTableColumn<Entity>[] {
+        return Object.entries(this.additionalFields).map(
+            ([fieldName, fieldValue]) => {
+                // Special handling for Channel Metadata Filename
+                if (fieldName === 'ChannelMetadataFilename') {
+                    return {
+                        name: fieldName,
+                        selector: fieldName,
+                        cell: (cellData: Entity) => {
+                            const url = getChannelMetadataUrl(
+                                cellData.imageChannelMetadata
+                            );
+                            if (url) {
+                                return (
+                                    <CellViewerLink
+                                        name={fieldValue}
+                                        url={url}
+                                    />
+                                );
+                            }
+                            return '';
+                        },
+                    };
+                }
+
+                // Default rendering for other fields
+                return {
+                    name: fieldName,
+                    selector: fieldName,
+                    cell: (cellData: Entity) => {
+                        return Array.isArray(fieldValue)
+                            ? fieldValue.join(', ')
+                            : typeof fieldValue === 'object'
+                            ? JSON.stringify(fieldValue)
+                            : String(fieldValue);
+                    },
+                };
+            }
+        );
+    }
+
     private getViewDetailsCustomContent(): JSX.Element | undefined {
         if (this.viewDetailsFileMetadata?.isPending) {
             return (
                 <div className={commonStyles.loadingIndicator}>
-                    <FontAwesomeIcon icon={faHourglassStart} /> Loading full
-                    metadata...
+                    <ScaleLoader />
                 </div>
             );
         }
@@ -1352,8 +1416,11 @@ export class FileTable extends React.Component<IFileTableProps> {
                     columns={this.columns.filter(
                         (c) => c.name !== DETAILS_COLUMN_NAME
                     )}
-                    additionalFields={this.getAdditionalFields()}
+                    additionalColumns={this.metadataColumnsFromFields}
                     disabledAddColumns={this.getDisabledAddColumns()}
+                    isLoadingAdditionalData={
+                        !!this.viewDetailsFileMetadata?.isPending
+                    }
                     customContent={this.getViewDetailsCustomContent()}
                 />
 


### PR DESCRIPTION
Fix #915

<img width="743" height="62" alt="Screenshot 2026-08-04 at 5 43 59 PM" src="https://github.com/user-attachments/assets/38f7c492-0058-46d0-92f3-3b5f15ae3b91" />

`Channel Metadata Filename` in Metadata modal is now a linkout when the actual link exists (even without a thumbnail).

Preview: https://htan-portal-nextjs-git-fork-onursumer-improve-view-101893-htan.vercel.app/explore/phase1?tab=File&selectedFilters=%5B%7B%22value%22%3A%22Other+and+Ill-defined+Sites%22%2C%22group%22%3A%22organType%22%2C%22count%22%3A2%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22tif%22%2C%22group%22%3A%22FileFormat%22%2C%22count%22%3A4%2C%22isSelected%22%3Afalse%7D%5D
