### PR TITLE
Add Cell Explorer as a viewer to the explore page

### DIFF
--- a/components/PublicationTabs.tsx
+++ b/components/PublicationTabs.tsx
@@ -59,7 +59,7 @@ const toolsContent: { [id: string]: JSX.Element[] } = {
                 <a
                     href={
                         typeof window !== 'undefined'
-                            ? `//${window.location.host}/explore?selectedFilters=%5B%7B%22value%22%3A%22mIHC%22%2C%22label%22%3A%22mIHC%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A62%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22CyCIF%22%2C%22label%22%3A%22CyCIF%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A400%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22MIBI%22%2C%22label%22%3A%22MIBI%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A165%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22IMC%22%2C%22label%22%3A%22IMC%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A41%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22H%26E%22%2C%22label%22%3A%22H%26E%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A254%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22CyCIF%22%2C%22label%22%3A%22CyCIF%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A13%2C%22isSelected%22%3Afalse%7D%2C%7B%22group%22%3A%22AtlasName%22%2C%22value%22%3A%22HTAN+Duke%22%7D%5D&tab=file`
+                            ? `//${window.location.host}/explore/phase1?selectedFilters=%5B%7B%22value%22%3A%22mIHC%22%2C%22label%22%3A%22mIHC%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A62%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22CyCIF%22%2C%22label%22%3A%22CyCIF%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A400%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22MIBI%22%2C%22label%22%3A%22MIBI%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A165%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22IMC%22%2C%22label%22%3A%22IMC%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A41%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22H%26E%22%2C%22label%22%3A%22H%26E%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A254%2C%22isSelected%22%3Afalse%7D%2C%7B%22value%22%3A%22CyCIF%22%2C%22label%22%3A%22CyCIF%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A13%2C%22isSelected%22%3Afalse%7D%2C%7B%22group%22%3A%22AtlasName%22%2C%22value%22%3A%22HTAN+Duke%22%7D%5D&tab=file`
                             : ''
                     }
                     target="_blank"
@@ -80,7 +80,7 @@ const toolsContent: { [id: string]: JSX.Element[] } = {
                 <a
                     href={
                         typeof window !== 'undefined'
-                            ? `//${window.location.host}/explore?selectedFilters=%5B%7B"group"%3A"AtlasName"%2C"value"%3A"HTAN+HMS"%7D%2C%7B"value"%3A"OME-TIFF"%2C"label"%3A"OME-TIFF"%2C"group"%3A"FileFormat"%2C"count"%3A16%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"Malignant+melanoma+NOS"%2C"label"%3A"Malignant+melanoma+NOS"%2C"group"%3A"PrimaryDiagnosis"%2C"count"%3A22%2C"isSelected"%3Afalse%7D%5D&tab=file`
+                            ? `//${window.location.host}/explore/phase1?selectedFilters=%5B%7B"group"%3A"AtlasName"%2C"value"%3A"HTAN+HMS"%7D%2C%7B"value"%3A"OME-TIFF"%2C"label"%3A"OME-TIFF"%2C"group"%3A"FileFormat"%2C"count"%3A16%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"Malignant+melanoma+NOS"%2C"label"%3A"Malignant+melanoma+NOS"%2C"group"%3A"PrimaryDiagnosis"%2C"count"%3A22%2C"isSelected"%3Afalse%7D%5D&tab=file`
                             : ''
                     }
                     target="_blank"
@@ -171,7 +171,7 @@ const toolsContent: { [id: string]: JSX.Element[] } = {
                 <a
                     href={
                         typeof window !== 'undefined'
-                            ? `//${window.location.host}/explore?selectedFilters=%5B%7B%22value%22%3A%22H%26E%22%2C%22label%22%3A%22H%26E%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A692%2C%22isSelected%22%3Afalse%7D%2C%7B%22group%22%3A%22AtlasName%22%2C%22value%22%3A%22HTAN+Vanderbilt%22%7D%5D&tab=file`
+                            ? `//${window.location.host}/explore/phase1?selectedFilters=%5B%7B%22value%22%3A%22H%26E%22%2C%22label%22%3A%22H%26E%22%2C%22group%22%3A%22assayName%22%2C%22count%22%3A692%2C%22isSelected%22%3Afalse%7D%2C%7B%22group%22%3A%22AtlasName%22%2C%22value%22%3A%22HTAN+Vanderbilt%22%7D%5D&tab=file`
                             : ''
                     }
                     target="_blank"
@@ -190,7 +190,7 @@ const toolsContent: { [id: string]: JSX.Element[] } = {
                 <a
                     href={
                         typeof window !== 'undefined'
-                            ? `//${window.location.host}/explore?selectedFilters=%5B%7B"value"%3A"hdf5"%2C"label"%3A"hdf5"%2C"group"%3A"FileFormat"%2C"count"%3A11%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"HTAN+Vanderbilt"%2C"label"%3A"HTAN+Vanderbilt"%2C"group"%3A"AtlasName"%2C"count"%3A4%2C"isSelected"%3Afalse%7D%5D&tab=file`
+                            ? `//${window.location.host}/explore/phase1?selectedFilters=%5B%7B"value"%3A"hdf5"%2C"label"%3A"hdf5"%2C"group"%3A"FileFormat"%2C"count"%3A11%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"HTAN+Vanderbilt"%2C"label"%3A"HTAN+Vanderbilt"%2C"group"%3A"AtlasName"%2C"count"%3A4%2C"isSelected"%3Afalse%7D%5D&tab=file`
                             : ''
                     }
                     target="_blank"
@@ -219,7 +219,7 @@ const toolsContent: { [id: string]: JSX.Element[] } = {
             >
                 <a
                     href={
-                        'https://humantumoratlas.org/explore?selectedFilters=%5B%7B%22value%22%3A%22hdf5%22%2C%22label%22%3A%22hdf5%22%2C%22group%22%3A%22FileFormat%22%2C%22count%22%3A11%2C%22isSelected%22%3Afalse%7D%2C%7B%22group%22%3A%22AtlasName%22%2C%22value%22%3A%22HTAN+CHOP%22%7D%5D&tab=file'
+                        'https://humantumoratlas.org/explore/phase1?selectedFilters=%5B%7B%22value%22%3A%22hdf5%22%2C%22label%22%3A%22hdf5%22%2C%22group%22%3A%22FileFormat%22%2C%22count%22%3A11%2C%22isSelected%22%3Afalse%7D%2C%7B%22group%22%3A%22AtlasName%22%2C%22value%22%3A%22HTAN+CHOP%22%7D%5D&tab=file'
                     }
                     target="_blank"
                 >
@@ -236,7 +236,7 @@ const toolsContent: { [id: string]: JSX.Element[] } = {
                 <a
                     href={
                         typeof window !== 'undefined'
-                            ? `//${window.location.host}/explore?selectedFilters=%5B%7B"value"%3A"hdf5"%2C"label"%3A"hdf5"%2C"group"%3A"FileFormat"%2C"count"%3A11%2C"isSelected"%3Afalse%7D%2C%7B"group"%3A"AtlasName"%2C"value"%3A"HTAN+CHOP"%7D%5D&tab=file`
+                            ? `//${window.location.host}/explore/phase1?selectedFilters=%5B%7B"value"%3A"hdf5"%2C"label"%3A"hdf5"%2C"group"%3A"FileFormat"%2C"count"%3A11%2C"isSelected"%3Afalse%7D%2C%7B"group"%3A"AtlasName"%2C"value"%3A"HTAN+CHOP"%7D%5D&tab=file`
                             : ''
                     }
                     target="_blank"

--- a/components/SummaryChart.tsx
+++ b/components/SummaryChart.tsx
@@ -132,7 +132,7 @@ function generateBaseExploreUrl(
 
     const urlParams = urlEncodeSelectedFilters(filters);
 
-    return `/explore?selectedFilters=${urlParams}`;
+    return `/explore/phase1?selectedFilters=${urlParams}`;
 }
 
 const TooltipContent: React.FunctionComponent<TooltipDatum> = (props) => {
@@ -229,7 +229,10 @@ export default class SummaryChart extends React.Component<SummaryChartProps> {
 
     get leftPadding() {
         if (this.categoryLabels.length > 0) {
-            const longestLabel = _.maxBy(this.categoryLabels, (l) => l?.length ?? 0);
+            const longestLabel = _.maxBy(
+                this.categoryLabels,
+                (l) => l?.length ?? 0
+            );
             return (longestLabel?.length ?? 0) * 8;
         } else {
             return 100;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -57,7 +57,7 @@ function addQueryStringToURL(
 }
 
 export function getExplorePageURL(tab: ExploreTab, filters: SelectedFilter[]) {
-    let url = '/explore';
+    let url = '/explore/phase1';
     if (filters.length > 0) {
         const query: ExploreURLQuery = {
             selectedFilters: urlEncodeSelectedFilters(filters),

--- a/packages/data-portal-explore/src/components/AtlasTable.tsx
+++ b/packages/data-portal-explore/src/components/AtlasTable.tsx
@@ -190,7 +190,7 @@ const ViewerCount: React.FunctionComponent<IAtlasViewerCountProps> = (
         { group: 'viewersArr', value: props.fileViewerName },
         { group: 'AtlasName', value: props.atlas.htan_name },
     ]);
-    const defaultHref = `/explore?selectedFilters=${filterString}&tab=file`;
+    const defaultHref = `/explore/phase1?selectedFilters=${filterString}&tab=file`;
     const hrefOverride = props.hrefOverride?.[props.atlas.htan_name];
 
     return (

--- a/packages/data-portal-explore/src/components/AtlasTable.tsx
+++ b/packages/data-portal-explore/src/components/AtlasTable.tsx
@@ -69,6 +69,47 @@ const MetaDataLink = (props: { id: string; baseUrl: string }) => (
     </a>
 );
 
+const CELL_EXPLORER_BASE_URL = 'https://cell-explorer.cbioportal.org';
+
+// Cell Explorer groups single cell datasets into collections, one per study, so
+// an atlas can map to several. The count in the column is the number of
+// collections, matching how the other viewer columns count what they link to.
+const CELL_EXPLORER_COLLECTIONS: {
+    [atlasName: string]: { slug: string; name: string }[];
+} = {
+    'HTAN CHOP': [
+        { slug: 'htan-chop-phgg', name: 'Pediatric High-Grade Glioma' },
+        { slug: 'htan-chop-nbl', name: 'High-Risk Neuroblastoma' },
+        { slug: 'htan-chop-ball', name: 'Infant KMT2Ar B-ALL' },
+    ],
+    'HTAN MSK': [
+        { slug: 'htan-msk-sclc', name: 'Small Cell Lung Cancer' },
+        { slug: 'htan-msk-treg', name: 'Regulatory T Cells in the TME' },
+        {
+            slug: 'crc-metastasis',
+            name: 'Progressive Plasticity During CRC Metastasis',
+        },
+    ],
+    'HTAN HTAPP': [
+        {
+            slug: 'htan-htapp-brca',
+            name: 'Breast Cancer Metastatic Microenvironment',
+        },
+    ],
+    'HTAN Vanderbilt': [
+        { slug: 'htan-vumc-crc', name: 'Pre-Malignant Colorectal Programs' },
+    ],
+};
+
+// A single collection deep-links to its own page. Several collections have no
+// single page to land on -- Cell Explorer has no per-atlas view -- so the count
+// links to the catalog, whose default tab lists every collection.
+function cellExplorerHref(collections: { slug: string }[]) {
+    return collections.length === 1
+        ? `${CELL_EXPLORER_BASE_URL}/collections/${collections[0].slug}`
+        : CELL_EXPLORER_BASE_URL;
+}
+
 const AtlasMetadataLinkModal: React.FunctionComponent<IAtlasMetadataLinkModalProps> = (
     props
 ) => {
@@ -648,6 +689,60 @@ export class AtlasTable extends React.Component<IAtlasTableProps> {
                         </Tooltip>
                     </>
                 ),
+            },
+            {
+                name: (
+                    <>
+                        <Tooltip
+                            overlay={
+                                <>Cell Explorer: explore single cell data</>
+                            }
+                        >
+                            {/* Glyph-only ("reverse") icon: dark mark on a
+                                transparent background, matching the other
+                                viewer icons on this light table header. */}
+                            <img
+                                width={20}
+                                src={
+                                    'https://raw.githubusercontent.com/cBioPortal/cbioportal-cell-explorer/main/packages/highperformer/public/icon-glyph.svg'
+                                }
+                            />
+                        </Tooltip>
+                    </>
+                ),
+                id: 'Cell Explorer: explore single cell data',
+                selector: 'htan_id', // dummy selector - you need to put something or else nothing will render
+                grow: 0.1,
+                right: true,
+                minWidth: '10',
+                cell: (atlas: AtlasTableData) => {
+                    const collections =
+                        CELL_EXPLORER_COLLECTIONS[atlas.htan_name] || [];
+
+                    if (collections.length === 0) {
+                        return null;
+                    }
+
+                    return (
+                        <Tooltip
+                            overlay={
+                                <>
+                                    Cell Explorer:{' '}
+                                    {collections.map((c) => c.name).join(', ')}
+                                </>
+                            }
+                        >
+                            <span className="ml-auto">
+                                <a
+                                    href={cellExplorerHref(collections)}
+                                    target="_blank"
+                                >
+                                    {collections.length}
+                                </a>
+                            </span>
+                        </Tooltip>
+                    );
+                },
             },
         ];
     }

--- a/packages/data-portal-explore/src/components/AtlasTable.tsx
+++ b/packages/data-portal-explore/src/components/AtlasTable.tsx
@@ -665,82 +665,51 @@ export class AtlasTable extends React.Component<IAtlasTableProps> {
                 grow: 0.1,
                 right: true,
                 minWidth: '10',
-                cell: (atlas: AtlasTableData) => (
-                    <>
-                        <Tooltip overlay="cBioPortal: explore multimodal cancer data">
-                            <span className="ml-auto">
-                                {atlas.htan_name === 'HTAN OHSU' && (
-                                    <a
-                                        href="https://www.cbioportal.org/patient?studyId=brca_hta9_htan_2022&caseId=HTA9_1"
-                                        target="_blank"
-                                    >
-                                        1
-                                    </a>
-                                )}
-                                {atlas.htan_name === 'HTAN Vanderbilt' && (
-                                    <a
-                                        href="https://www.cbioportal.org/study/summary?id=crc_hta11_htan_2021"
-                                        target="_blank"
-                                    >
-                                        1
-                                    </a>
-                                )}
-                            </span>
-                        </Tooltip>
-                    </>
-                ),
-            },
-            {
-                name: (
-                    <>
-                        <Tooltip
-                            overlay={
-                                <>Cell Explorer: explore single cell data</>
-                            }
-                        >
-                            {/* Glyph-only ("reverse") icon: dark mark on a
-                                transparent background, matching the other
-                                viewer icons on this light table header. */}
-                            <img
-                                width={20}
-                                src={
-                                    'https://raw.githubusercontent.com/cBioPortal/cbioportal-cell-explorer/main/packages/highperformer/public/icon-glyph.svg'
-                                }
-                            />
-                        </Tooltip>
-                    </>
-                ),
-                id: 'Cell Explorer: explore single cell data',
-                selector: 'htan_id', // dummy selector - you need to put something or else nothing will render
-                grow: 0.1,
-                right: true,
-                minWidth: '10',
                 cell: (atlas: AtlasTableData) => {
                     const collections =
                         CELL_EXPLORER_COLLECTIONS[atlas.htan_name] || [];
 
-                    if (collections.length === 0) {
+                    const cbioportalLink =
+                        atlas.htan_name === 'HTAN OHSU'
+                            ? 'https://www.cbioportal.org/patient?studyId=brca_hta9_htan_2022&caseId=HTA9_1'
+                            : atlas.htan_name === 'HTAN Vanderbilt'
+                            ? 'https://www.cbioportal.org/study/summary?id=crc_hta11_htan_2021'
+                            : null;
+
+                    if (!cbioportalLink && collections.length === 0) {
                         return null;
                     }
 
                     return (
-                        <Tooltip
-                            overlay={
-                                <>
-                                    Cell Explorer:{' '}
-                                    {collections.map((c) => c.name).join(', ')}
-                                </>
-                            }
-                        >
-                            <span className="ml-auto">
-                                <a
-                                    href={cellExplorerHref(collections)}
-                                    target="_blank"
+                        <span className="ml-auto">
+                            {cbioportalLink && (
+                                <Tooltip overlay="cBioPortal: explore multimodal cancer data">
+                                    <a href={cbioportalLink} target="_blank">
+                                        1
+                                    </a>
+                                </Tooltip>
+                            )}
+                            {cbioportalLink && collections.length > 0 && ' | '}
+                            {collections.length > 0 && (
+                                <Tooltip
+                                    overlay={
+                                        <>
+                                            Cell Explorer:{' '}
+                                            {collections
+                                                .map((c) => c.name)
+                                                .join(', ')}
+                                        </>
+                                    }
                                 >
-                                    {collections.length}
-                                </a>
-                            </span>
-                        </Tooltip>
+                                    <a
+                                        href={cellExplorerHref(collections)}
+                                        target="_blank"
+                                    >
+                                        {collections.length}
+                                    </a>
+                                </Tooltip>
+                            )}
+                        </span>
                     );
                 },
             },

--- a/packages/data-portal-explore/src/components/AtlasTable.tsx
+++ b/packages/data-portal-explore/src/components/AtlasTable.tsx
@@ -676,41 +676,43 @@ export class AtlasTable extends React.Component<IAtlasTableProps> {
                             ? 'https://www.cbioportal.org/study/summary?id=crc_hta11_htan_2021'
                             : null;
 
-                    if (!cbioportalLink && collections.length === 0) {
-                        return null;
-                    }
-
-                    return (
-                        <span className="ml-auto">
-                            {cbioportalLink && (
-                                <Tooltip overlay="cBioPortal: explore multimodal cancer data">
+                    if (cbioportalLink) {
+                        return (
+                            <Tooltip overlay="cBioPortal: explore multimodal cancer data">
+                                <span className="ml-auto">
                                     <a href={cbioportalLink} target="_blank">
                                         1
                                     </a>
-                                </Tooltip>
-                            )}
-                            {cbioportalLink && collections.length > 0 && ' | '}
-                            {collections.length > 0 && (
-                                <Tooltip
-                                    overlay={
-                                        <>
-                                            Cell Explorer:{' '}
-                                            {collections
-                                                .map((c) => c.name)
-                                                .join(', ')}
-                                        </>
-                                    }
-                                >
+                                </span>
+                            </Tooltip>
+                        );
+                    }
+
+                    if (collections.length > 0) {
+                        return (
+                            <Tooltip
+                                overlay={
+                                    <>
+                                        Cell Explorer:{' '}
+                                        {collections
+                                            .map((c) => c.name)
+                                            .join(', ')}
+                                    </>
+                                }
+                            >
+                                <span className="ml-auto">
                                     <a
                                         href={cellExplorerHref(collections)}
                                         target="_blank"
                                     >
                                         {collections.length}
                                     </a>
-                                </Tooltip>
-                            )}
-                        </span>
-                    );
+                                </span>
+                            </Tooltip>
+                        );
+                    }
+
+                    return null;
                 },
             },
         ];

--- a/pages/static/data-access.html
+++ b/pages/static/data-access.html
@@ -10,7 +10,7 @@ The HTAN Portal leverages several repositories to provide access to data:
         <a href="https://www.synapse.org/" target="_blank">Synapse</a> - Open
         Acccess Processed
         <a
-            href="https://humantumoratlas.org/explore?tab=file&selectedFilters=%5B%7B%22group%22%3A%22level%22%2C%22value%22%3A%22Level+3%22%7D%2C%7B%22group%22%3A%22level%22%2C%22value%22%3A%22Level+4%22%7D%5D"
+            href="https://humantumoratlas.org/explore/phase1?tab=file&selectedFilters=%5B%7B%22group%22%3A%22level%22%2C%22value%22%3A%22Level+3%22%7D%2C%7B%22group%22%3A%22level%22%2C%22value%22%3A%22Level+4%22%7D%5D"
             >level 3 and level 4</a
         >
         data
@@ -64,7 +64,7 @@ The HTAN Portal leverages several repositories to provide access to data:
 Instructions for accessing data from these repositories can be found directly
 from the
 <a
-    href='/explore?selectedFilters=%5B%7B"value"%3A"dbGaP"%2C"label"%3A"dbGaP+%28Access+Controlled%29"%2C"group"%3A"downloadSource"%2C"count"%3A19734%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"dbGaP+and+IDC"%2C"label"%3A"dbGaP+and+IDC"%2C"group"%3A"downloadSource"%2C"count"%3A227%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"Synapse"%2C"label"%3A"Synapse+%28Level+3-4%29"%2C"group"%3A"downloadSource"%2C"count"%3A3038%2C"isSelected"%3Afalse%7D%5D'
+    href='/explore/phase1?selectedFilters=%5B%7B"value"%3A"dbGaP"%2C"label"%3A"dbGaP+%28Access+Controlled%29"%2C"group"%3A"downloadSource"%2C"count"%3A19734%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"dbGaP+and+IDC"%2C"label"%3A"dbGaP+and+IDC"%2C"group"%3A"downloadSource"%2C"count"%3A227%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"Synapse"%2C"label"%3A"Synapse+%28Level+3-4%29"%2C"group"%3A"downloadSource"%2C"count"%3A3038%2C"isSelected"%3Afalse%7D%5D'
     >Explore Page</a
 >
 by making a selection of files and clicking on the download button. More

--- a/pages/static/data-updates.html
+++ b/pages/static/data-updates.html
@@ -383,7 +383,7 @@ navText: Data Updates
 <p>
     Vanderbilt has
     <a
-        href='/explore?selectedFilters=%5B%7B"group"%3A"AtlasName"%2C"value"%3A"HTAN+Vanderbilt"%7D%2C%7B"value"%3A"Bulk+DNA"%2C"label"%3A"Bulk+DNA"%2C"group"%3A"assayName"%2C"count"%3A353%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"Level+3"%2C"label"%3A"Level+3"%2C"group"%3A"Level"%2C"count"%3A62%2C"isSelected"%3Afalse%7D%5D&tab=file'
+        href='/explore/phase1?selectedFilters=%5B%7B"group"%3A"AtlasName"%2C"value"%3A"HTAN+Vanderbilt"%7D%2C%7B"value"%3A"Bulk+DNA"%2C"label"%3A"Bulk+DNA"%2C"group"%3A"assayName"%2C"count"%3A353%2C"isSelected"%3Afalse%7D%2C%7B"value"%3A"Level+3"%2C"label"%3A"Level+3"%2C"group"%3A"Level"%2C"count"%3A62%2C"isSelected"%3Afalse%7D%5D&tab=file'
         >Level 3 BulkDNASeq data</a
     >
     available now


### PR DESCRIPTION
Adds cBioPortal Cell Explorer under the cBioPortal icon of the Phase 1 explore atlas table, linking atlases to their single cell datasets on [cell-explorer.cbioportal.org](https://cell-explorer.cbioportal.org).

## What shows up

| Atlas | Count | Links to |
|---|---|---|
| HTAN CHOP | 3 | catalog |
| HTAN MSK | 3 | catalog |
| HTAN HTAPP | 1 | `/collections/htan-htapp-brca` |
| HTAN Vanderbilt | 1 | `/collections/htan-vumc-crc` |

Other atlases render nothing, as the other viewer columns do when they have no data. Hovering a count lists the collection names.

## Notes for review

**Why the count is what it is.** Cell Explorer groups single cell datasets into collections, one per study, so an atlas can map to several — CHOP and MSK have three each. The number shown is the collection count, matching how the other viewer columns count what they link to.

**Why some rows link to the catalog rather than a specific page.** A single collection deep-links to its own page. Cell Explorer has no per-atlas view, so an atlas with several collections links to the catalog, whose default tab lists them all. Adding an `?atlas=` filter to Cell Explorer would let every row deep-link; that is a change in `cbioportal-cell-explorer` and is not attempted here.

**Why this doesn't use `ViewerCount`.** That component renders only when `atlas.viewerCounts[viewerName] > 0`, which comes from HTAN file metadata. These datasets are not HTAN files carrying viewer counts, so the column would always be empty. The cBioPortal column has the same constraint and solves it the same way, with its own `cell`.

**Icon.** The glyph-only Cell Explorer mark, dark on transparent, matching the other icons on this light header. Served from `raw.githubusercontent.com`, as the existing icons are served from GitHub user content.

## Testing

`yarn buildPackages` passes and `AtlasTable.tsx` typechecks clean. Verified with `yarn dev` on the Phase 1 explore page: the column renders, counts land on the correct rows, tooltips list the right collections, and the icon displays correctly in both light and dark OS appearance.

## Maintenance

`CELL_EXPLORER_COLLECTIONS` is a static map. New Cell Explorer collections need an entry here; nothing breaks if it goes stale, the affected atlas simply shows a lower count or none.

<img width="450" height="395" alt="image" src="https://github.com/user-attachments/assets/046ba989-d59c-44fd-9df1-1bab5bf5931e" />
